### PR TITLE
Replace NETBSD paths with MINIXSRCDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@
 #	Populate ${RELEASEDIR}/${RELEASEMACHINEDIR}/binary/sets
 #	from ${DESTDIR}
 #   sourcesets:
-#	Populate ${RELEASEDIR}/source/sets from ${NETBSDSRCDIR}
+#	Populate ${RELEASEDIR}/source/sets from ${MINIXSRCDIR}
 #   syspkgs:
 #	Populate ${RELEASEDIR}/${RELEASEMACHINEDIR}/binary/syspkgs
 #	from ${DESTDIR}
@@ -274,7 +274,7 @@ includes-gnu:	.PHONY includes-lib
 #
 # This is referenced by _NETBSD_VERSION_DEPENDS in <bsd.own.mk>.
 #
-.include "${NETBSDSRCDIR}/etc/Makefile.params"
+.include "${MINIXSRCDIR}/etc/Makefile.params"
 CLEANDIRFILES+= params
 params: .EXEC
 	${_MKMSG_CREATE} params
@@ -411,7 +411,7 @@ installmodules: .PHONY .MAKE
 	@printf "make ${.TARGET} finished at: " && date
 
 #
-# Create sets from $DESTDIR or $NETBSDSRCDIR into $RELEASEDIR
+# Create sets from $DESTDIR or $MINIXSRCDIR into $RELEASEDIR
 #
 
 .for tgt in sets sourcesets syspkgs

--- a/build.sh
+++ b/build.sh
@@ -571,7 +571,10 @@ initdefaults()
 
 	# Set source directories
 	#
-	setmakeenv NETBSDSRCDIR "${TOP}"
+        # Define source tree location
+        setmakeenv MINIXSRCDIR "${TOP}"
+        # Legacy variable for compatibility with NetBSD build scripts
+        setmakeenv NETBSDSRCDIR "${MINIXSRCDIR}"
 
 	# Make sure KERNOBJDIR is an absolute path if defined
 	#
@@ -1971,7 +1974,8 @@ diskimage()
 	kernel="${kerneldir}/netbsd-${ARG}.gz"
 	[ -f "${kernel}" ] ||
 	    bomb "The kernel ${kernel} must be built first"
-	make_in_dir "${NETBSDSRCDIR}/etc" "smp_${1}"
+        # Build disk image using source tree paths
+        make_in_dir "${MINIXSRCDIR}/etc" "smp_${1}"
 }
 
 buildkernel()
@@ -2123,8 +2127,8 @@ dorump()
 	export RUMPKERN_ONLY=1
 	# create obj and distrib dirs
 	if [ "${MKOBJDIRS}" != "no" ]; then
-		make_in_dir "${NETBSDSRCDIR}/etc/mtree" obj
-		make_in_dir "${NETBSDSRCDIR}/sys/rump" obj
+                make_in_dir "${MINIXSRCDIR}/etc/mtree" obj
+                make_in_dir "${MINIXSRCDIR}/sys/rump" obj
 	fi
 	${runcmd} "${makewrapper}" ${parallel} do-distrib-dirs \
 	    || bomb 'could not create distrib-dirs'
@@ -2137,13 +2141,13 @@ dorump()
 		setmakeenv NOPROFILE 1
 	fi
 	for cmd in ${targlist} ; do
-		make_in_dir "${NETBSDSRCDIR}/sys/rump" ${cmd}
+                make_in_dir "${MINIXSRCDIR}/sys/rump" ${cmd}
 	done
 
 	# if we just wanted to build & install rump, we're done
 	[ "${1}" != "rumptest" ] && return
 
-	${runcmd} cd "${NETBSDSRCDIR}/sys/rump/librump/rumpkern" \
+        ${runcmd} cd "${MINIXSRCDIR}/sys/rump/librump/rumpkern" \
 	    || bomb "cd to rumpkern failed"
 	md_quirks=`${runcmd} "${makewrapper}" -V '${_SYMQUIRK}'`
 	# one little, two little, three little backslashes ...

--- a/share/mk/bsd.README
+++ b/share/mk/bsd.README
@@ -544,11 +544,11 @@ is included.  These files may define any of the variables described below.
 <bsd.own.mk> sets the following variables, if they are not already defined
 (defaults are in brackets):
 
-NETBSDSRCDIR	Top of the NetBSD source tree.
-		If _SRC_TOP_ != "", that will be used as the default,
-		otherwise BSDSRCDIR will be used as the default.
-		Various makefiles within the NetBSD source tree will
-		use this to reference the top level of the source tree.
+MINIXSRCDIR     Top of the Minix source tree.
+If _SRC_TOP_ != "", that will be used as the default,
+otherwise BSDSRCDIR will be used as the default.
+Various makefiles within the source tree will
+use this to reference the top level of the source tree.
 
 _SRC_TOP_	Top of the system source tree, as determined by <bsd.own.mk>
 		based on the presence of tools/ and build.sh.  This variable
@@ -560,10 +560,10 @@ _NETBSD_VERSION_DEPENDS
 		the version of the NetBSD being built.  This is
 		defined only if the current directory appears
 		to be inside a NetBSD source tree.  The list of
-		files includes ${NETBSDSRCDIR}/sys/sys/param.h
+		files includes ${MINIXSRCDIR}/sys/sys/param.h
 		(which contains the kernel version number),
-		${NETBSDSRCDIR}/sys/conf/newvers.sh and
-		${NETBSDSRCDIR}/sys/conf/osrelease.sh (which
+		${MINIXSRCDIR}/sys/conf/newvers.sh and
+		${MINIXSRCDIR}/sys/conf/osrelease.sh (which
 		interpret the information in sys/sys/param.h), and
 		${_SRC_TOP_OBJ_}/params (which is an optional file,
 		created by "make build" in ${_SRC_TOP_}/Makefile,
@@ -639,7 +639,7 @@ NLSOWN		Native Language Support files owner.  [root]
 
 NLSMODE		Native Language Support files mode.  [${NONBINMODE}]
 
-X11SRCDIR	The path to the xsrc tree.  [${NETBSDSRCDIR}/../xsrc,
+X11SRCDIR	The path to the xsrc tree.  [${MINIXSRCDIR}/../xsrc,
 		if that exists; otherwise /usr/xsrc]
 
 X11SRCDIR.local	The path to the local X11 src tree.  [${X11SRCDIR}/local]

--- a/share/mk/bsd.hostprog.mk
+++ b/share/mk/bsd.hostprog.mk
@@ -117,7 +117,7 @@ ${HOSTPROG}: ${OBJS} ${DPADD}
 	${_MKTARGET_LINK}
 	${HOST_LINK.c} ${HOST_LDSTATIC} -o ${.TARGET} ${OBJS} ${LDADD}
 .if !empty(.MAKE.OS:M*CYGWIN*)
-	${HOST_SH} ${NETBSDSRCDIR}/tools/binstall/mkmanifest ${HOSTPROG}
+	${HOST_SH} ${MINIXSRCDIR}/tools/binstall/mkmanifest ${HOSTPROG}
 .endif
 
 

--- a/share/mk/bsd.kernobj.mk
+++ b/share/mk/bsd.kernobj.mk
@@ -1,7 +1,7 @@
 #	$NetBSD: bsd.kernobj.mk,v 1.14 2013/06/03 07:39:07 mrg Exp $
 
 # KERNSRCDIR	Is the location of the top of the kernel src.
-# 		It defaults to `${NETBSDSRCDIR}/sys'.
+# 		It defaults to `${MINIXSRCDIR}/sys'.
 #
 # KERNARCHDIR	Is the location of the machine dependent kernel sources.
 #		It defaults to `arch/${MACHINE}', but may be overridden
@@ -23,7 +23,7 @@
 
 .include <bsd.own.mk>
 
-KERNSRCDIR?=		${NETBSDSRCDIR}/sys
+KERNSRCDIR?=		${MINIXSRCDIR}/sys
 KERNARCHDIR?=		arch/${MACHINE}
 KERNCONFDIRDEFAULT?=	${KERNSRCDIR}/${KERNARCHDIR}/conf
 KERNCONFDIR?=		${KERNCONFDIRDEFAULT}

--- a/share/mk/bsd.klinks.mk
+++ b/share/mk/bsd.klinks.mk
@@ -7,8 +7,8 @@ KLINK_MACHINE?=	${MACHINE}
 
 ##### Default values
 .if !defined(S)
-.if defined(NETBSDSRCDIR)
-S=	${NETBSDSRCDIR}/sys
+.if defined(MINIXSRCDIR)
+S=	${MINIXSRCDIR}/sys
 .elif defined(BSDSRCDIR)
 S=	${BSDSRCDIR}/sys
 .else

--- a/share/mk/bsd.lib.mk
+++ b/share/mk/bsd.lib.mk
@@ -75,11 +75,11 @@ DPADD+=	${SHLIB_VERSION_FILE}
 
 # Check for higher installed library versions.
 .if !defined(NOCHECKVER) && !defined(NOCHECKVER_${LIB}) && \
-	exists(${NETBSDSRCDIR}/lib/checkver)
+	exists(${MINIXSRCDIR}/lib/checkver)
 checkver:
 	@(cd "${.CURDIR}" && \
 	    HOST_SH=${HOST_SH:Q} AWK=${TOOL_AWK:Q} \
-	    ${HOST_SH} ${NETBSDSRCDIR}/lib/checkver -v ${SHLIB_VERSION_FILE} \
+	    ${HOST_SH} ${MINIXSRCDIR}/lib/checkver -v ${SHLIB_VERSION_FILE} \
 		    -d ${_DEST.OBJ} ${LIB})
 .endif
 .endif									# }
@@ -212,7 +212,7 @@ SHLIB_SHFLAGS+= -L ${DESTDIR}/usr/lib
 SHLIB_SHFLAGS+= -Wl,-plugin=${GOLD_PLUGIN} \
 		-Wl,-plugin-opt=-disable-opt
 
-SECTIONIFYPASS?=${NETBSDSRCDIR}/minix/llvm/bin/sectionify.so
+SECTIONIFYPASS?=${MINIXSRCDIR}/minix/llvm/bin/sectionify.so
 # dcvmoole: the following construction is a hack for libmagicrt.  For reasons
 # not entirely under our control, clang refuses to take .bc objects even when
 # using the gold linker, saying that LLVM IR code cannot be linked.  In order

--- a/share/mk/bsd.own.mk
+++ b/share/mk/bsd.own.mk
@@ -55,8 +55,8 @@ MKSKEY:=	no
 MKYP:=		no
 MKCROSSGDB:=	no
 
-WEAKALIASOVERRIDEPASS?=${NETBSDSRCDIR}/minix/llvm/bin/weak-alias-module-override.so
-GOLD_PLUGIN?=${NETBSDSRCDIR}/minix/llvm/bin/LLVMgold.so
+WEAKALIASOVERRIDEPASS?=${MINIXSRCDIR}/minix/llvm/bin/weak-alias-module-override.so
+GOLD_PLUGIN?=${MINIXSRCDIR}/minix/llvm/bin/LLVMgold.so
 
 # By default when running LLVM passes:
 #  -  do not run optimization while running LLVM passes
@@ -334,7 +334,8 @@ _SRC_TOP_!= cd "${.CURDIR}"; while :; do \
 #
 .if (${_SRC_TOP_} != "")		# {
 
-NETBSDSRCDIR?=	${_SRC_TOP_}
+MINIXSRCDIR?=  ${_SRC_TOP_}
+NETBSDSRCDIR?=  ${MINIXSRCDIR}
 
 .if !defined(_SRC_TOP_OBJ_)
 _SRC_TOP_OBJ_!=		cd "${_SRC_TOP_}" && ${PRINTOBJDIR}
@@ -342,9 +343,9 @@ _SRC_TOP_OBJ_!=		cd "${_SRC_TOP_}" && ${PRINTOBJDIR}
 .endif
 
 _NETBSD_VERSION_DEPENDS=	${_SRC_TOP_OBJ_}/params
-_NETBSD_VERSION_DEPENDS+=	${NETBSDSRCDIR}/sys/sys/param.h
-_NETBSD_VERSION_DEPENDS+=	${NETBSDSRCDIR}/sys/conf/newvers.sh
-_NETBSD_VERSION_DEPENDS+=	${NETBSDSRCDIR}/sys/conf/osrelease.sh
+_NETBSD_VERSION_DEPENDS+=	${MINIXSRCDIR}/sys/sys/param.h
+_NETBSD_VERSION_DEPENDS+=	${MINIXSRCDIR}/sys/conf/newvers.sh
+_NETBSD_VERSION_DEPENDS+=	${MINIXSRCDIR}/sys/conf/osrelease.sh
 ${_SRC_TOP_OBJ_}/params: .NOTMAIN .OPTIONAL # created by top level "make build"
 
 .endif	# _SRC_TOP_ != ""		# }
@@ -863,7 +864,8 @@ MKDYNAMICROOT?=	yes
 #
 BSDSRCDIR?=	/usr/src
 BSDOBJDIR?=	/usr/obj
-NETBSDSRCDIR?=	${BSDSRCDIR}
+MINIXSRCDIR?=      ${BSDSRCDIR}
+NETBSDSRCDIR?=      ${MINIXSRCDIR}
 
 BINGRP?=	wheel
 BINOWN?=	root
@@ -1448,13 +1450,13 @@ SYMLINK?=	-l s
 
 METALOG?=	${DESTDIR}/METALOG
 METALOG.add?=	${TOOL_CAT} -l >> ${METALOG}
-.if (${_SRC_TOP_} != "")	# only set INSTPRIV if inside ${NETBSDSRCDIR}
+.if (${_SRC_TOP_} != "")	# only set INSTPRIV if inside ${MINIXSRCDIR}
 .if ${MKUNPRIVED} != "no"
 INSTPRIV.unpriv=-U -M ${METALOG} -D ${DESTDIR} -h sha256
 .else
 INSTPRIV.unpriv=
 .endif
-INSTPRIV?=	${INSTPRIV.unpriv} -N ${NETBSDSRCDIR}/etc
+INSTPRIV?=	${INSTPRIV.unpriv} -N ${MINIXSRCDIR}/etc
 .endif
 STRIPFLAG?=	
 
@@ -1535,8 +1537,8 @@ TOOL_GZIP_N=		${TOOL_GZIP} ${GZIP_N_FLAG}
 # Where X11 sources are and where it is installed to.
 #
 .if !defined(X11SRCDIR)
-.if exists(${NETBSDSRCDIR}/../xsrc)
-X11SRCDIR!=		cd "${NETBSDSRCDIR}/../xsrc" && pwd
+.if exists(${MINIXSRCDIR}/../xsrc)
+X11SRCDIR!=		cd "${MINIXSRCDIR}/../xsrc" && pwd
 .else
 X11SRCDIR=		/usr/xsrc
 .endif
@@ -1634,8 +1636,8 @@ X11LOADABLE?=			yes
 # Where extsrc sources are and where it is installed to.
 #
 .if !defined(EXTSRCSRCDIR)
-.if exists(${NETBSDSRCDIR}/../extsrc)
-EXTSRCSRCDIR!=		cd "${NETBSDSRCDIR}/../extsrc" && pwd
+.if exists(${MINIXSRCDIR}/../extsrc)
+EXTSRCSRCDIR!=		cd "${MINIXSRCDIR}/../extsrc" && pwd
 .else
 EXTSRCSRCDIR=		/usr/extsrc
 .endif

--- a/share/mk/bsd.sys.mk
+++ b/share/mk/bsd.sys.mk
@@ -29,7 +29,7 @@ MKDEPCXX?= CC=${CXX:Q} mkdep
 .endif # defined(__MINIX)
 
 .if ${MKREPRO:Uno} == "yes"
-CPPFLAGS+=	-Wp,-iremap,${NETBSDSRCDIR}:/usr/src
+CPPFLAGS+=	-Wp,-iremap,${MINIXSRCDIR}:/usr/src
 CPPFLAGS+=	-Wp,-iremap,${DESTDIR}/:/
 CPPFLAGS+=	-Wp,-iremap,${X11SRCDIR}:/usr/xsrc
 .endif

--- a/share/mk/bsd.syscall.mk
+++ b/share/mk/bsd.syscall.mk
@@ -5,7 +5,7 @@
 SYSCALL_OBJS?=	${SYSCALL_PREFIX}_sysent.c ${SYSCALL_PREFIX}_syscalls.c \
 	${SYSCALL_PREFIX}_syscall.h ${SYSCALL_PREFIX}_syscallargs.h
 
-SYSCALL_DEPS?=	${NETBSDSRCDIR}/sys/kern/makesyscalls.sh \
+SYSCALL_DEPS?=	${MINIXSRCDIR}/sys/kern/makesyscalls.sh \
 	syscalls.conf syscalls.master
 
 all: ${SYSCALL_OBJS}

--- a/share/mk/minix.service.mk
+++ b/share/mk/minix.service.mk
@@ -47,7 +47,7 @@ CPPFLAGS += -D_MINIX_SYSTEM=1
 # on them, unless they have specifically requested to be built without bitcode.
 .if ${USE_BITCODE:Uno} == "yes" && ${USE_MAGIC:Uno} == "yes"
 LIBMAGICST?= ${DESTDIR}${LIBDIR}/libmagicrt.bcc
-MAGICPASS?= ${NETBSDSRCDIR}/minix/llvm/bin/magic.so
+MAGICPASS?= ${MINIXSRCDIR}/minix/llvm/bin/magic.so
 
 DPADD+= ${LIBMAGICST} ${MAGICPASS}
 
@@ -61,7 +61,7 @@ OPTFLAGS+= -load ${MAGICPASS} -magic ${MAGICFLAGS}
 # For MKASR builds, generate an additional set of rerandomized service
 # binaries.
 .if ${USE_ASR:Uno} == "yes"
-ASRPASS?= ${NETBSDSRCDIR}/minix/llvm/bin/asr.so
+ASRPASS?= ${MINIXSRCDIR}/minix/llvm/bin/asr.so
 ASRCOUNT?= 3
 ASRDIR?= /usr/service/asr
 

--- a/share/mk/sys.mk
+++ b/share/mk/sys.mk
@@ -86,7 +86,7 @@ CXXFLAGS?=	${CFLAGS:N-Wno-traditional:N-Wstrict-prototypes:N-Wmissing-prototypes
 
 __ALLSRC1=	${empty(DESTDIR):?${.ALLSRC}:${.ALLSRC:S|^${DESTDIR}|^destdir|}}
 __ALLSRC2=	${empty(MAKEOBJDIR):?${__ALLSRC1}:${__ALLSRC1:S|^${MAKEOBJDIR}|^obj|}}
-__ALLSRC3=	${empty(NETBSDSRCDIR):?${__ALLSRC2}:${__ALLSRC2:S|^${NETBSDSRCDIR}|^src|}}
+__ALLSRC3=	${empty(MINIXSRCDIR):?${__ALLSRC2}:${__ALLSRC2:S|^${MINIXSRCDIR}|^src|}}
 __BUILDSEED=	${BUILDSEED}/${__ALLSRC3:O}/${.TARGET}
 _CXXSEED?=	${BUILDSEED:D-frandom-seed=${__BUILDSEED:hash}}
 


### PR DESCRIPTION
## Summary
- introduce `MINIXSRCDIR` and use it throughout the build system
- remove NetBSD-specific references in Makefile and share/mk files
- document `MINIXSRCDIR` in `bsd.README`

## Testing
- `make -n` *(fails: Makefile:106: missing separator)*
- `./build.sh -n help | head -n 5`