### PR TITLE
Remove outdated NetBSD note in config

### DIFF
--- a/minix/include/minix/config.h
+++ b/minix/include/minix/config.h
@@ -3,8 +3,8 @@
 
 /* Minix release and version numbers. */
 #define OS_NAME "Minix"
-#define OS_RELEASE "3.4.0"	/* 3.m.p */
-#define OS_REV 304000000	/* see NetBSD sys/param.h: 3mm00pp00 */
+#define OS_RELEASE "3.4.0" /* 3.m.p */
+#define OS_REV 304000000
 #define OS_CONFIG "GENERIC"
 #define OS_VERSION OS_NAME " " OS_RELEASE " (" OS_CONFIG ")"
 
@@ -23,84 +23,87 @@
 #include <minix/sys_config.h>
 
 /* Number of slots in the process table for non-kernel processes. The number
- * of system processes defines how many processes with special privileges 
- * there can be. User processes share the same properties and count for one. 
+ * of system processes defines how many processes with special privileges
+ * there can be. User processes share the same properties and count for one.
  *
  * These can be changed in sys_config.h.
  */
-#define NR_PROCS 	  _NR_PROCS 
-#define NR_SYS_PROCS      _NR_SYS_PROCS
-#define NR_SYS_CHUNKS	  BITMAP_CHUNKS(NR_SYS_PROCS)
+#define NR_PROCS _NR_PROCS
+#define NR_SYS_PROCS _NR_SYS_PROCS
+#define NR_SYS_CHUNKS BITMAP_CHUNKS(NR_SYS_PROCS)
 
 /* Number of controller tasks (/dev/cN device classes). */
-#define NR_CTRLRS          2
+#define NR_CTRLRS 2
 
 /* DMA_SECTORS may be increased to speed up DMA based drivers. */
-#define DMA_SECTORS        1	/* DMA buffer size (must be >= 1) */
+#define DMA_SECTORS 1 /* DMA buffer size (must be >= 1) */
 
 /* NR_CONS, NR_RS_LINES, and NR_PTYS determine the number of terminals the
  * system can handle.
  */
-#define NR_CONS            4	/* # system consoles (1 to 8) */
-#define	NR_RS_LINES	   4	/* # rs232 terminals (0 to 3) */
-#define	NR_PTYS		   32	/* # pseudo terminals (0 to 64) */
+#define NR_CONS 4     /* # system consoles (1 to 8) */
+#define NR_RS_LINES 4 /* # rs232 terminals (0 to 3) */
+#define NR_PTYS 32    /* # pseudo terminals (0 to 64) */
 
 /* This feature enable the counting of system calls in PM and FS */
-#define ENABLE_SYSCALL_STATS	0
+#define ENABLE_SYSCALL_STATS 0
 
 /* Max. number of I/O ranges that can be assigned to a process */
-#define NR_IO_RANGE	64
+#define NR_IO_RANGE 64
 
 /* Max. number of device memory ranges that can be assigned to a process */
-#define NR_MEM_RANGE	20
+#define NR_MEM_RANGE 20
 
 /* Max. number of IRQs that can be assigned to a process */
-#define NR_IRQ	16
+#define NR_IRQ 16
 
 /* Max. number of domains (protocol families) per socket driver */
-#define NR_DOMAIN	8
+#define NR_DOMAIN 8
 
 /* Scheduling priorities. Values must start at zero (highest
  * priority) and increment.
  */
-#define NR_SCHED_QUEUES   16	/* MUST equal minimum priority + 1 */
-#define TASK_Q		   0	/* highest, used for kernel tasks */
-#define MAX_USER_Q  	   0    /* highest priority for user processes */   
-#define USER_Q  	  ((MIN_USER_Q - MAX_USER_Q) / 2 + MAX_USER_Q) /* default
-						(should correspond to nice 0) */
-#define MIN_USER_Q	  (NR_SCHED_QUEUES - 1)	/* minimum priority for user
-						   processes */
+#define NR_SCHED_QUEUES 16 /* MUST equal minimum priority + 1 */
+#define TASK_Q 0           /* highest, used for kernel tasks */
+#define MAX_USER_Q 0       /* highest priority for user processes */
+#define USER_Q                                                                 \
+  ((MIN_USER_Q - MAX_USER_Q) / 2 + MAX_USER_Q) /* default                      \
+                        (should correspond to nice 0) */
+#define MIN_USER_Q                                                             \
+  (NR_SCHED_QUEUES - 1) /* minimum priority for user                           \
+                           processes */
 /* default scheduling quanta */
 #define USER_QUANTUM 200
 
 /* defualt user process cpu */
-#define USER_DEFAULT_CPU	-1 /* use the default cpu or do not change the
-				      current one */
+#define USER_DEFAULT_CPU                                                       \
+  -1 /* use the default cpu or do not change the                               \
+        current one */
 
 /*===========================================================================*
  *	There are no user-settable parameters after this line		     *
  *===========================================================================*/
 /* Set the FP_FORMAT type based on the machine selected, either hw or sw    */
-#define FP_NONE	 _FP_NONE	/* no floating point support                */
-#define FP_IEEE	 _FP_IEEE	/* conform IEEE floating point standard     */
+#define FP_NONE _FP_NONE /* no floating point support                */
+#define FP_IEEE _FP_IEEE /* conform IEEE floating point standard     */
 
 /* _MINIX_FP_FORMAT is defined in sys_config.h. */
-#define FP_FORMAT	_MINIX_FP_FORMAT
+#define FP_FORMAT _MINIX_FP_FORMAT
 
 /* _ASKDEV and _FASTLOAD are defined in sys_config.h. */
 #define ASKDEV _ASKDEV
 #define FASTLOAD _FASTLOAD
 
 /* Enable or disable system profiling. */
-#define SPROFILE          0    /* statistical profiling */
+#define SPROFILE 0 /* statistical profiling */
 
 /* PCI configuration parameters */
 #define NR_PCIBUS 40
 #define NR_PCIDEV 50
 
 /* Network device driver protocol parameters. */
-#define NDEV_NAME_MAX	16	/* max network driver name length (incl nul) */
-#define NDEV_HWADDR_MAX	6	/* max network hardware address length */
-#define NDEV_IOV_MAX	8	/* max number of elements in I/O vector */
+#define NDEV_NAME_MAX 16  /* max network driver name length (incl nul) */
+#define NDEV_HWADDR_MAX 6 /* max network hardware address length */
+#define NDEV_IOV_MAX 8    /* max number of elements in I/O vector */
 
 #endif /* _CONFIG_H */


### PR DESCRIPTION
## Summary
- tidy `config.h` OS revision info
- run clang-format for consistent style

## Testing
- `clang-format -i minix/include/minix/config.h`