### PR TITLE
Fix wording for MINIX CPUSTATES messages

### DIFF
--- a/minix/include/minix/const.h
+++ b/minix/include/minix/const.h
@@ -168,10 +168,9 @@
 #define MKF_I386_AMD_SYSCALL	(1L << 1) /* SYSCALL available and supported */
 
 /*
- * Number of per-CPU states for which time will be accounted.  This *must* be
- * the same value as NetBSD's CPUSTATES, which is defined in a rather
- * unfortunate location (sys/sched.h).  If the NetBSD value changes, our kernel
- * must be adapted accordingly.
+ * Number of per-CPU states for which time will be accounted.  This value must
+ * remain in sync with CPUSTATES defined in sys/sched.h.  When CPUSTATES
+ * changes, the MINIX kernel code must be updated accordingly.
  */
 #define MINIX_CPUSTATES	5
 

--- a/minix/kernel/arch/earm/arch_clock.c
+++ b/minix/kernel/arch/earm/arch_clock.c
@@ -12,7 +12,7 @@
 #include <sys/sched.h> /* for CP_*, CPUSTATES */
 #if CPUSTATES != MINIX_CPUSTATES
 /* If this breaks, the code in this file may have to be adapted accordingly. */
-#error "MINIX_CPUSTATES value is out of sync with NetBSD's!"
+#error "MINIX_CPUSTATES value is out of sync with CPUSTATES!"
 #endif
 
 #include "kernel/spinlock.h"

--- a/minix/kernel/arch/i386/arch_clock.c
+++ b/minix/kernel/arch/i386/arch_clock.c
@@ -9,7 +9,7 @@
 #include <sys/sched.h> /* for CP_*, CPUSTATES */
 #if CPUSTATES != MINIX_CPUSTATES
 /* If this breaks, the code in this file may have to be adapted accordingly. */
-#error "MINIX_CPUSTATES value is out of sync with NetBSD's!"
+#error "MINIX_CPUSTATES value is out of sync with CPUSTATES!"
 #endif
 
 #ifdef USE_APIC

--- a/minix/lib/libsys/cpuavg.c
+++ b/minix/lib/libsys/cpuavg.c
@@ -263,14 +263,15 @@ cpuavg_getstats(const struct cpuavg * ca_orig, uint32_t * cpticks,
 
 	*cpticks = ca.ca_run >> FSHIFT;
 
-	/*
-	 * NetBSD's estcpu value determines a scheduling queue, and decays to
-	 * 10% in 5*(the current load average) seconds.  Our 'estcpu' simply
-	 * reports the process's percentage of CPU usage in the last second,
-	 * thus yielding a value in the range 0..100 with a decay of 100% after
-	 * one second.  This should be good enough for most practical purposes.
-	 */
-	*estcpu = (ca.ca_last / hz * 100) >> FSHIFT;
+        /*
+         * In traditional BSD kernels, the 'estcpu' value determines a
+         * scheduling queue and decays to 10% in 5*(the current load average)
+         * seconds.  MINIX reports the process's percentage of CPU usage in the
+         * last second instead, yielding a value in the range 0..100 with a
+         * decay of 100% after one second.  This should be good enough for most
+         * practical purposes.
+         */
+        *estcpu = (ca.ca_last / hz * 100) >> FSHIFT;
 
 	return ca.ca_avg;
 }

--- a/minix/net/uds/io.c
+++ b/minix/net/uds/io.c
@@ -520,12 +520,13 @@ uds_send_peer(struct udssock * uds, const struct sockaddr * addr,
 		} else
 			peer = uds->uds_link;
 
-		/*
-		 * If the receiving end will never receive this packet, we
-		 * might as well not send it, so drop it immeiately.  Indicate
-		 * as such to the caller, using NetBSD's chosen error code.
-		 */
-		if (uds_is_shutdown(peer, SFL_SHUT_RD))
+                /*
+                 * If the receiving end will never receive this packet, we
+                 * might as well not send it, so drop it immediately.  Indicate
+                 * this condition to the caller using the MINIX error code for a
+                 * full buffer.
+                 */
+                if (uds_is_shutdown(peer, SFL_SHUT_RD))
 			return ENOBUFS;
 	} else {
 		assert(uds_has_conn(uds));
@@ -669,9 +670,10 @@ uds_send_data(struct udssock * uds, struct udssock * peer,
 	if (seglen > avail) {
 		assert(uds_get_type(uds) == SOCK_DGRAM);
 
-		/* Drop the packet, borrowing NetBSD's chosen error code. */
-		return ENOBUFS;
-	}
+                /* Drop the packet and return the MINIX error code for
+                 * insufficient buffer space. */
+                return ENOBUFS;
+        }
 
 	/*
 	 * Generate the full segment, but do not yet update the buffer head.

--- a/minix/servers/vfs/read.c
+++ b/minix/servers/vfs/read.c
@@ -344,11 +344,11 @@ int rw_pipe(int rw_flag, endpoint_t usr_e, struct filp *f, int callnr, int fd,
 	if (r == SUSPEND)
 		pipe_suspend(callnr, fd, buf, nbytes, cum_io);
 
-	/* If pipe_check returns an error instead of suspending the call, we
-	 * return that error, even if we are resuming a partially completed
-	 * operation (ie, a large blocking write), to match NetBSD's behavior.
-	 */
-	return(r);
+        /* If pipe_check returns an error instead of suspending the call, we
+         * return that error, even if we are resuming a partially completed
+         * operation (ie, a large blocking write), to follow MINIX semantics.
+         */
+        return(r);
   }
 
   size = r;


### PR DESCRIPTION
## Summary
- improve MINIX-centric error texts for CPUSTATES mismatch
- describe MINIX behaviour in cpu average comments
- update pipe and socket comments to MINIX wording

## Testing
- `make -C tests` *(fails: missing separator)*