### PR TITLE
Replace __NetBSD__ checks with MINIX-specific conditionals

### DIFF
--- a/lib/libc/gen/vis.c
+++ b/lib/libc/gen/vis.c
@@ -134,7 +134,7 @@ static const wchar_t char_shell[] = L"'`\";&<>()|{}]\\$!^~";
 static const wchar_t char_glob[] = L"*?[#";
 
 #if !HAVE_NBTOOL_CONFIG_H
-#if !defined(__NetBSD__) && ! defined(__minix)
+#ifndef __minix
 /*
  * On NetBSD MB_LEN_MAX is currently 32 which does not fit on any integer
  * integral type and it is probably wrong, since currently the maximum
@@ -154,7 +154,7 @@ static const wchar_t char_glob[] = L"*?[#";
 #endif
 #endif /* __FreeBSD__ */
 CTASSERT(MB_LEN_MAX <= sizeof(uint64_t));
-#endif /* !__NetBSD__ */
+#endif /* !__minix */
 #endif
 
 /*

--- a/lib/libc/include/port_before.h
+++ b/lib/libc/include/port_before.h
@@ -2,7 +2,7 @@
 #include <sys/cdefs.h>
 #define ISC_FORMAT_PRINTF(a,b) __attribute__((__format__(__printf__,a,b)))
 #define ISC_SOCKLEN_T	socklen_t
-#ifdef __NetBSD__
+#ifdef __minix
 #define DE_CONST(c,v)	v = __UNCONST(c)
 #else
 #define DE_CONST(c,v)	v = ((c) ? \

--- a/lib/libc/stdlib/jemalloc.c
+++ b/lib/libc/stdlib/jemalloc.c
@@ -97,13 +97,13 @@
 
 /* LINTLIBRARY */
 
-#if defined(__NetBSD__) || defined(__minix)
+#ifdef __minix
 #  define xutrace(a, b)		utrace("malloc", (a), (b))
 #  define __DECONST(x, y)	((x)__UNCONST(y))
 #  define NO_TLS
 #else
 #  define xutrace(a, b)		utrace((a), (b))
-#endif	/* __NetBSD__ */
+#endif /* __minix */
 
 /*
  * MALLOC_PRODUCTION disables assertions and statistics gathering.  It also
@@ -159,7 +159,7 @@ __RCSID("$NetBSD: jemalloc.c,v 1.38 2015/07/26 17:21:55 martin Exp $");
 #include <strings.h>
 #include <unistd.h>
 
-#ifdef __NetBSD__
+#ifdef __minix
 #  include <reentrant.h>
 #  include "extern.h"
 
@@ -184,7 +184,7 @@ __strerror_r(int e, char *s, size_t l)
 	}
 	return slen >= l ? ERANGE : rval;
 }
-#endif
+#endif /* __minix */
 
 #ifdef __FreeBSD__
 #define STRERROR_R(a, b, c)	strerror_r(a, b, c);
@@ -941,11 +941,11 @@ static bool	malloc_init_hard(void);
  * Begin mutex.
  */
 
-#ifdef __NetBSD__
+#ifdef __minix
 #define	malloc_mutex_init(m)	mutex_init(m, NULL)
 #define	malloc_mutex_lock(m)	mutex_lock(m)
 #define	malloc_mutex_unlock(m)	mutex_unlock(m)
-#else	/* __NetBSD__ */
+#else  /* __minix */
 static inline void
 malloc_mutex_init(malloc_mutex_t *a_mutex)
 {
@@ -969,7 +969,7 @@ malloc_mutex_unlock(malloc_mutex_t *a_mutex)
 	if (__isthreaded)
 		_SPINUNLOCK(&a_mutex->lock);
 }
-#endif	/* __NetBSD__ */
+#endif /* __minix */
 
 /*
  * End mutex.
@@ -3952,7 +3952,7 @@ free(void *ptr)
 /*
  * Begin non-standard functions.
  */
-#ifndef __NetBSD__
+#ifndef __minix
 size_t
 malloc_usable_size(const void *ptr)
 {

--- a/lib/libc/stdlib/malloc.c
+++ b/lib/libc/stdlib/malloc.c
@@ -104,27 +104,31 @@ void utrace(struct ut *, int);
 #endif /* defined(__minix) */
 
 #include <sys/types.h>
-#if defined(__NetBSD__)
-#   define malloc_minsize               16U
-#   define HAS_UTRACE
-#   define UTRACE_LABEL "malloc",
+#ifdef __minix /* MINIX-specific tracing and locking */
+#define malloc_minsize 16U
+#define HAS_UTRACE
+#define UTRACE_LABEL "malloc",
 #include <sys/cdefs.h>
 #include "extern.h"
 #if defined(LIBC_SCCS) && !defined(lint)
-__RCSID("$NetBSD: malloc.c,v 1.56 2014/09/18 13:58:20 christos Exp $");
+    __RCSID("$NetBSD: malloc.c,v 1.56 2014/09/18 13:58:20 christos Exp $");
 #endif /* LIBC_SCCS and not lint */
-int utrace(const char *, void *, size_t);
+    int utrace(const char *, void *, size_t);
 
 #include <reentrant.h>
-extern int __isthreaded;
-static mutex_t thread_lock = MUTEX_INITIALIZER;
-#define _MALLOC_LOCK()	if (__isthreaded) mutex_lock(&thread_lock);
-#define _MALLOC_UNLOCK()	if (__isthreaded) mutex_unlock(&thread_lock);
-#endif /* __NetBSD__ */
+    extern int __isthreaded;
+    static mutex_t thread_lock = MUTEX_INITIALIZER;
+#define _MALLOC_LOCK()                                                     \
+      if (__isthreaded)                                                        \
+        mutex_lock(&thread_lock);
+#define _MALLOC_UNLOCK()                                                   \
+      if (__isthreaded)                                                        \
+        mutex_unlock(&thread_lock);
+#endif /* __minix */
 
 #if defined(__sparc__) && defined(sun)
-#   define malloc_minsize		16U
-#   define MAP_ANON			(0)
+#define malloc_minsize 16U
+#define MAP_ANON (0)
     static int fdzero;
 #   define MMAP_FD	fdzero
 #   define INIT_MMAP() \

--- a/lib/libc/stdlib/strfmon.c
+++ b/lib/libc/stdlib/strfmon.c
@@ -36,10 +36,10 @@ __RCSID("$NetBSD: strfmon.c,v 1.10 2012/03/21 14:19:15 christos Exp $");
 #endif
 #endif /* LIBC_SCCS and not lint */
 
-#if defined(__NetBSD__) || defined(__minix)
+#ifdef __minix /* MINIX uses namespace wrappers */
 #include "namespace.h"
 #include <monetary.h>
-#endif
+#endif /* __minix */
 
 #include <sys/types.h>
 #include <assert.h>

--- a/lib/libc/time/private.h
+++ b/lib/libc/time/private.h
@@ -90,7 +90,7 @@
 ** Nested includes
 */
 
-#if !defined(__NetBSD__) && !defined(__minix)
+#ifndef __minix
 /* Avoid clashes with NetBSD by renaming NetBSD's declarations.  */
 #define localtime_rz sys_localtime_rz
 #define mktime_z sys_mktime_z
@@ -406,7 +406,7 @@ void tzset(void);
 extern char *	asctime_r(struct tm const *restrict, char *restrict);
 #endif
 
-#if defined(USG_COMPAT) && !defined(__NetBSD__) && !defined(__minix)
+#if defined(USG_COMPAT) && !defined(__minix)
 # ifndef timezone
 extern long timezone;
 # endif
@@ -449,9 +449,8 @@ time_t posix2time(time_t);
 
 /* Infer TM_ZONE on systems where this information is known, but suppress
    guessing if NO_TM_ZONE is defined.  Similarly for TM_GMTOFF.  */
-#if (defined __GLIBC__ \
-     || defined __FreeBSD__ || defined __minix || defined __NetBSD__ || defined __OpenBSD__ \
-     || (defined __APPLE__ && defined __MACH__))
+#if (defined __GLIBC__ || defined __FreeBSD__ || defined __minix ||            \
+     defined __OpenBSD__ || (defined __APPLE__ && defined __MACH__))
 # if !defined TM_GMTOFF && !defined NO_TM_GMTOFF
 #  define TM_GMTOFF tm_gmtoff
 # endif
@@ -468,7 +467,7 @@ time_t posix2time(time_t);
 ** is not done here.  What we call 'struct state' NetBSD calls
 ** 'struct __state', but this is a private name so it doesn't matter.
 */
-#if !defined(__NetBSD__) && !defined(__minix)
+#ifndef __minix
 #if NETBSD_INSPIRED
 typedef struct state *timezone_t;
 struct tm *localtime_rz(timezone_t restrict, time_t const *restrict,

--- a/lib/libc/time/zdump.c
+++ b/lib/libc/time/zdump.c
@@ -98,9 +98,8 @@ typedef long intmax_t;
 
 /* Infer TM_ZONE on systems where this information is known, but suppress
    guessing if NO_TM_ZONE is defined.  Similarly for TM_GMTOFF.  */
-#if (defined __GLIBC__ \
-     || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ \
-     || (defined __APPLE__ && defined __MACH__))
+#if (defined __GLIBC__ || defined __FreeBSD__ || defined __minix ||            \
+     defined __OpenBSD__ || (defined __APPLE__ && defined __MACH__))
 # if !defined TM_GMTOFF && !defined NO_TM_GMTOFF
 #  define TM_GMTOFF tm_gmtoff
 # endif

--- a/lib/libedit/chartype.h
+++ b/lib/libedit/chartype.h
@@ -45,7 +45,8 @@
  * seems to actually advertise this properly, despite Unicode 3.1 having
  * been around since 2001... */
 #if !defined(__minix)
-#if !defined(__NetBSD__) && !defined(__sun) && !(defined(__APPLE__) && defined(__MACH__)) && !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#if !defined(__sun) && !(defined(__APPLE__) && defined(__MACH__)) &&           \
+    !defined(__OpenBSD__) && !defined(__FreeBSD__)
 #ifndef __STDC_ISO_10646__
 /* In many places it is assumed that the first 127 code points are ASCII
  * compatible, so ensure wchar_t indeed does ISO 10646 and not some other

--- a/usr.bin/make/job.c
+++ b/usr.bin/make/job.c
@@ -229,7 +229,7 @@ static int     	  numCommands; 	    /* The number of commands actually printed
 #define DEFSHELL_INDEX 0	/* DEFSHELL_INDEX_CUSTOM or DEFSHELL_INDEX_SH */
 #endif /* !DEFSHELL_INDEX */
 
-static Shell    shells[] = {
+static Shell shells[] = {
 #ifdef DEFSHELL_CUSTOM
     /*
      * An sh-compatible shell with a non-standard name.
@@ -238,60 +238,106 @@ static Shell    shells[] = {
      * non-portable features that might not be supplied by all
      * sh-compatible shells.
      */
-{
-    DEFSHELL_CUSTOM,
-    FALSE, "", "", "", 0,
-    FALSE, "echo \"%s\"\n", "%s\n", "{ %s \n} || exit $?\n", "'\n'", '#',
-    "",
-    "",
-},
+    {
+        DEFSHELL_CUSTOM,
+        FALSE,
+        "",
+        "",
+        "",
+        0,
+        FALSE,
+        "echo \"%s\"\n",
+        "%s\n",
+        "{ %s \n} || exit $?\n",
+        "'\n'",
+        '#',
+        "",
+        "",
+    },
 #endif /* DEFSHELL_CUSTOM */
-    /*
-     * SH description. Echo control is also possible and, under
-     * sun UNIX anyway, one can even control error checking.
-     */
-{
-    "sh",
-    FALSE, "", "", "", 0,
-    FALSE, "echo \"%s\"\n", "%s\n", "{ %s \n} || exit $?\n", "'\n'", '#',
-#if defined(MAKE_NATIVE) && defined(__NetBSD__)
-    "q",
+       /*
+        * SH description. Echo control is also possible and, under
+        * sun UNIX anyway, one can even control error checking.
+        */
+    {
+        "sh",
+        FALSE,
+        "",
+        "",
+        "",
+        0,
+        FALSE,
+        "echo \"%s\"\n",
+        "%s\n",
+        "{ %s \n} || exit $?\n",
+        "'\n'",
+        '#',
+#if defined(MAKE_NATIVE) && defined(__minix)
+        "q",
 #else
     "",
 #endif
-    "",
-},
+        "",
+    },
     /*
-     * KSH description. 
+     * KSH description.
      */
-{
-    "ksh",
-    TRUE, "set +v", "set -v", "set +v", 6,
-    FALSE, "echo \"%s\"\n", "%s\n", "{ %s \n} || exit $?\n", "'\n'", '#',
-    "v",
-    "",
-},
+    {
+        "ksh",
+        TRUE,
+        "set +v",
+        "set -v",
+        "set +v",
+        6,
+        FALSE,
+        "echo \"%s\"\n",
+        "%s\n",
+        "{ %s \n} || exit $?\n",
+        "'\n'",
+        '#',
+        "v",
+        "",
+    },
     /*
      * CSH description. The csh can do echo control by playing
      * with the setting of the 'echo' shell variable. Sadly,
      * however, it is unable to do error control nicely.
      */
-{
-    "csh",
-    TRUE, "unset verbose", "set verbose", "unset verbose", 10,
-    FALSE, "echo \"%s\"\n", "csh -c \"%s || exit 0\"\n", "", "'\\\n'", '#',
-    "v", "e",
-},
+    {
+        "csh",
+        TRUE,
+        "unset verbose",
+        "set verbose",
+        "unset verbose",
+        10,
+        FALSE,
+        "echo \"%s\"\n",
+        "csh -c \"%s || exit 0\"\n",
+        "",
+        "'\\\n'",
+        '#',
+        "v",
+        "e",
+    },
     /*
      * UNKNOWN.
      */
-{
-    NULL,
-    FALSE, NULL, NULL, NULL, 0,
-    FALSE, NULL, NULL, NULL, NULL, 0,
-    NULL, NULL,
-}
-};
+    {
+        NULL,
+        FALSE,
+        NULL,
+        NULL,
+        NULL,
+        0,
+        FALSE,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        0,
+        NULL,
+        NULL,
+    }};
 static Shell *commandShell = &shells[DEFSHELL_INDEX]; /* this is the shell to
 						   * which we pass all
 						   * commands in the Makefile.

--- a/usr.bin/nbperf/nbperf.c
+++ b/usr.bin/nbperf/nbperf.c
@@ -61,7 +61,7 @@ void usage(void)
 	exit(1);
 }
 
-#if HAVE_NBTOOL_CONFIG_H && !defined(__NetBSD__)
+#if HAVE_NBTOOL_CONFIG_H && defined(__minix)
 #define	arc4random() rand()
 #endif
 

--- a/usr.bin/netstat/fast_ipsec.c
+++ b/usr.bin/netstat/fast_ipsec.c
@@ -32,7 +32,7 @@
 
 #include <sys/cdefs.h>
 #ifndef lint
-#ifdef __NetBSD__
+#ifdef __minix
 __RCSID("$NetBSD: fast_ipsec.c,v 1.20 2013/04/15 21:20:39 christos Exp $");
 #endif
 #endif /* not lint*/

--- a/usr.bin/netstat/pfkey.c
+++ b/usr.bin/netstat/pfkey.c
@@ -64,7 +64,7 @@
 #if 0
 static char sccsid[] = "from: @(#)inet.c	8.4 (Berkeley) 4/20/94";
 #else
-#ifdef __NetBSD__
+#ifdef __minix
 __RCSID("$NetBSD: pfkey.c,v 1.1 2012/01/06 14:21:16 drochner Exp $");
 #endif
 #endif

--- a/usr.sbin/rtadvd/rtadvd.c
+++ b/usr.sbin/rtadvd/rtadvd.c
@@ -54,7 +54,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <syslog.h>
-#if defined(__NetBSD__) || defined(__minix)
+#if defined(__minix)
 #include <util.h>
 #endif
 #include <poll.h>
@@ -255,8 +255,8 @@ main(int argc, char *argv[])
 
 	sock_open();
 
-#if defined(__NetBSD__) || defined(__minix)
-	/* record the current PID */
+#if defined(__minix)
+        /* record the current PID */
 	if (pidfile(NULL) < 0) {
 		syslog(LOG_ERR,
 		    "<%s> failed to open the pid log file, run anyway.",


### PR DESCRIPTION
## Summary
- remove `__NetBSD__` conditionals and use `__minix` or generic checks
- keep formatting tidy via `git clang-format`

## Testing
- `./build.sh -n -m i386 distribution` *(fails: PATH environment variable must not contain non-absolute components)*