### PR TITLE
Remove NetBSD references from infback9

### DIFF
--- a/common/dist/zlib/contrib/infback9/infback9.c
+++ b/common/dist/zlib/contrib/infback9/infback9.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: infback9.c,v 1.1.1.1 2006/01/14 20:10:50 christos Exp $	*/
-
 /* infback9.c -- inflate deflate64 data using a call-back interface
  * Copyright (C) 1995-2003 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h

--- a/common/dist/zlib/contrib/infback9/infback9.h
+++ b/common/dist/zlib/contrib/infback9/infback9.h
@@ -1,5 +1,3 @@
-/*	$NetBSD: infback9.h,v 1.1.1.1 2006/01/14 20:10:50 christos Exp $	*/
-
 /* infback9.h -- header for using inflateBack9 functions
  * Copyright (C) 2003 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h

--- a/common/dist/zlib/contrib/infback9/inffix9.h
+++ b/common/dist/zlib/contrib/infback9/inffix9.h
@@ -1,5 +1,3 @@
-/*	$NetBSD: inffix9.h,v 1.1.1.1 2006/01/14 20:10:51 christos Exp $	*/
-
     /* inffix9.h -- table for decoding deflate64 fixed codes
      * Generated automatically by makefixed9().
      */

--- a/common/dist/zlib/contrib/infback9/inflate9.h
+++ b/common/dist/zlib/contrib/infback9/inflate9.h
@@ -1,5 +1,3 @@
-/*	$NetBSD: inflate9.h,v 1.1.1.1 2006/01/14 20:10:51 christos Exp $	*/
-
 /* inflate9.h -- internal inflate state definition
  * Copyright (C) 1995-2003 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h

--- a/common/dist/zlib/contrib/infback9/inftree9.c
+++ b/common/dist/zlib/contrib/infback9/inftree9.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: inftree9.c,v 1.1.1.1 2006/01/14 20:10:52 christos Exp $	*/
-
 /* inftree9.c -- generate Huffman trees for efficient decoding
  * Copyright (C) 1995-2005 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h

--- a/common/dist/zlib/contrib/infback9/inftree9.h
+++ b/common/dist/zlib/contrib/infback9/inftree9.h
@@ -1,5 +1,3 @@
-/*	$NetBSD: inftree9.h,v 1.1.1.1 2006/01/14 20:10:52 christos Exp $	*/
-
 /* inftree9.h -- header to use inftree9.c
  * Copyright (C) 1995-2003 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h


### PR DESCRIPTION
## Summary
- clean comments by removing NetBSD CVS IDs in infback9 sources

## Testing
- `grep -n NetBSD -r common/dist/zlib/contrib/infback9`

------
https://chatgpt.com/codex/tasks/task_e_683a96fca77c8331bbd9ea8d9e107519