### PR TITLE
Remove NetBSD headers from zlib blast

### DIFF
--- a/common/dist/zlib/contrib/blast/blast.c
+++ b/common/dist/zlib/contrib/blast/blast.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: blast.c,v 1.1.1.1 2006/01/14 20:10:46 christos Exp $	*/
-
 /* blast.c
  * Copyright (C) 2003 Mark Adler
  * For conditions of distribution and use, see copyright notice in blast.h

--- a/common/dist/zlib/contrib/blast/blast.h
+++ b/common/dist/zlib/contrib/blast/blast.h
@@ -1,5 +1,3 @@
-/*	$NetBSD: blast.h,v 1.1.1.1 2006/01/14 20:10:46 christos Exp $	*/
-
 /* blast.h -- interface for blast.c
   Copyright (C) 2003 Mark Adler
   version 1.1, 16 Feb 2003


### PR DESCRIPTION
## Summary
- clean NetBSD headers from `common/dist/zlib/contrib/blast/blast.c`
- clean NetBSD headers from `common/dist/zlib/contrib/blast/blast.h`

## Testing
- `grep -n NetBSD -r common/dist/zlib/contrib/blast`

------
https://chatgpt.com/codex/tasks/task_e_683a96fa5e988331ba4a6cc6e5a780b4