### PR TITLE
Remove NetBSD references from test utility

### DIFF
--- a/bin/test/Makefile
+++ b/bin/test/Makefile
@@ -1,5 +1,5 @@
-#	$NetBSD: Makefile,v 1.11 2007/06/22 03:24:16 simonb Exp $
-#	@(#)Makefile	8.1 (Berkeley) 5/31/93
+# Makefile for the test utility
+# Derived from 4.4BSD sources
 
 PROG=	test
 SRCS=   test.c

--- a/bin/test/TEST.csh
+++ b/bin/test/TEST.csh
@@ -1,4 +1,4 @@
-#	$NetBSD: TEST.csh,v 1.2 1995/03/21 07:03:59 cgd Exp $
+# Test script for the test utility
 #	@(#)TEST.csh	5.2 (Berkeley) 4/30/93
 
 #alias t '/usr/src/bin/test/obj/test \!*; echo $status'

--- a/bin/test/test.1
+++ b/bin/test/test.1
@@ -1,4 +1,4 @@
-.\"	$NetBSD: test.1,v 1.30 2016/08/12 03:17:41 sevan Exp $
+.\" Manual page for the test utility
 .\"
 .\" Copyright (c) 1991, 1993
 .\"	The Regents of the University of California.  All rights reserved.


### PR DESCRIPTION
## Summary
- clean up `bin/test` by eliminating NetBSD references
- leave a neutral history comment in `test.c`
- tweak manual and scripts to be system-neutral
- reformat `test.c` with clang-format

## Testing
- `make` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_683a96eea1c48331b44651bd09a44bf8