### PR TITLE
Remove NetBSD headers from zlib examples

### DIFF
--- a/common/dist/zlib/examples/fitblk.c
+++ b/common/dist/zlib/examples/fitblk.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: fitblk.c,v 1.1.1.1 2006/01/14 20:11:08 christos Exp $	*/
-
 /* fitblk.c: example of fitting compressed output to a specified size
    Not copyrighted -- provided to the public domain
    Version 1.1  25 November 2004  Mark Adler */

--- a/common/dist/zlib/examples/gun.c
+++ b/common/dist/zlib/examples/gun.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: gun.c,v 1.1.1.1 2006/01/14 20:11:08 christos Exp $	*/
-
 /* gun.c -- simple gunzip to give an example of the use of inflateBack()
  * Copyright (C) 2003, 2005 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h

--- a/common/dist/zlib/examples/gzappend.c
+++ b/common/dist/zlib/examples/gzappend.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: gzappend.c,v 1.1.1.1 2006/01/14 20:11:08 christos Exp $	*/
-
 /* gzappend -- command to append to a gzip file
 
   Copyright (C) 2003 Mark Adler, all rights reserved

--- a/common/dist/zlib/examples/gzjoin.c
+++ b/common/dist/zlib/examples/gzjoin.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: gzjoin.c,v 1.1.1.1 2006/01/14 20:11:09 christos Exp $	*/
-
 /* gzjoin -- command to join gzip files into one gzip file
 
   Copyright (C) 2004 Mark Adler, all rights reserved

--- a/common/dist/zlib/examples/gzlog.c
+++ b/common/dist/zlib/examples/gzlog.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: gzlog.c,v 1.1.1.1 2006/01/14 20:11:09 christos Exp $	*/
-
 /*
  * gzlog.c
  * Copyright (C) 2004 Mark Adler

--- a/common/dist/zlib/examples/gzlog.h
+++ b/common/dist/zlib/examples/gzlog.h
@@ -1,5 +1,3 @@
-/*	$NetBSD: gzlog.h,v 1.1.1.1 2006/01/14 20:11:09 christos Exp $	*/
-
 /* gzlog.h
   Copyright (C) 2004 Mark Adler, all rights reserved
   version 1.0, 26 Nov 2004

--- a/common/dist/zlib/examples/zpipe.c
+++ b/common/dist/zlib/examples/zpipe.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: zpipe.c,v 1.1.1.1 2006/01/14 20:11:09 christos Exp $	*/
-
 /* zpipe.c: example of proper use of zlib's inflate() and deflate()
    Not copyrighted -- provided to the public domain
    Version 1.2  9 November 2004  Mark Adler */

--- a/common/dist/zlib/examples/zran.c
+++ b/common/dist/zlib/examples/zran.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: zran.c,v 1.1.1.1 2006/01/14 20:11:10 christos Exp $	*/
-
 /* zran.c -- example of zlib/gzip stream indexing and random access
  * Copyright (C) 2005 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h


### PR DESCRIPTION
## Summary
- cleanse NetBSD references from zlib example sources

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683a970b5d5083318b75899cbfd10e2e