### PR TITLE
Remove NetBSD RCS IDs and reformat compat tools

### DIFF
--- a/tools/compat/flock.c
+++ b/tools/compat/flock.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: flock.c,v 1.6 2008/04/28 20:24:12 martin Exp $	*/
-
 /*-
  * Copyright (c) 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
@@ -41,36 +39,36 @@
 #include <fcntl.h>
 
 int flock(int fd, int op) {
-	int rc = 0;
+  int rc = 0;
 
 #if defined(F_SETLK) && defined(F_SETLKW)
-	struct flock fl = {0};
+  struct flock fl = {0};
 
-	switch (op & (LOCK_EX|LOCK_SH|LOCK_UN)) {
-	case LOCK_EX:
-		fl.l_type = F_WRLCK;
-		break;
+  switch (op & (LOCK_EX | LOCK_SH | LOCK_UN)) {
+  case LOCK_EX:
+    fl.l_type = F_WRLCK;
+    break;
 
-	case LOCK_SH:
-		fl.l_type = F_RDLCK;
-		break;
+  case LOCK_SH:
+    fl.l_type = F_RDLCK;
+    break;
 
-	case LOCK_UN:
-		fl.l_type = F_UNLCK;
-		break;
+  case LOCK_UN:
+    fl.l_type = F_UNLCK;
+    break;
 
-	default:
-		errno = EINVAL;
-		return -1;
-	}
+  default:
+    errno = EINVAL;
+    return -1;
+  }
 
-	fl.l_whence = SEEK_SET;
-	rc = fcntl(fd, op & LOCK_NB ? F_SETLK : F_SETLKW, &fl);
+  fl.l_whence = SEEK_SET;
+  rc = fcntl(fd, op & LOCK_NB ? F_SETLK : F_SETLKW, &fl);
 
-	if (rc && (errno == EAGAIN))
-		errno = EWOULDBLOCK;
+  if (rc && (errno == EAGAIN))
+    errno = EWOULDBLOCK;
 #endif
 
-	return rc;
+  return rc;
 }
 #endif

--- a/tools/compat/fpurge.c
+++ b/tools/compat/fpurge.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: fpurge.c,v 1.1 2009/06/16 22:35:34 christos Exp $	*/
-
 /*-
  * Copyright (c) 2009 The NetBSD Foundation, Inc.
  * All rights reserved.
@@ -36,14 +34,12 @@
 #include "nbtool_config.h"
 
 #if !HAVE_FPURGE
-#include <stdio.h>
 #include <fcntl.h>
+#include <stdio.h>
 
-void
-fpurge(FILE *fp)
-{
+void fpurge(FILE *fp) {
 #if HAVE___FPURGE
-	__fpurge(fp);
+  __fpurge(fp);
 #endif
 }
 #endif

--- a/tools/compat/getmode.c
+++ b/tools/compat/getmode.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: getmode.c,v 1.8 2008/11/04 23:31:32 dbj Exp $	*/
-
 /*-
  * Copyright (c) 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
@@ -33,25 +31,21 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void *
-setmode(const char *str)
-{
-	mode_t *mp = malloc(sizeof(mode_t));
+void *setmode(const char *str) {
+  mode_t *mp = malloc(sizeof(mode_t));
 
-	*mp = strtoul(str, NULL, 8);
+  *mp = strtoul(str, NULL, 8);
 
-	return mp;
+  return mp;
 }
 
-mode_t
-getmode(const void *mp, mode_t mode)
-{
-	mode_t m;
+mode_t getmode(const void *mp, mode_t mode) {
+  mode_t m;
 
-	m = *((const mode_t *)mp);
+  m = *((const mode_t *)mp);
 
-	mode &= ~ALLPERMS;	/* input mode less RWX permissions */
-	m &= ALLPERMS;		/* new RWX permissions */
+  mode &= ~ALLPERMS; /* input mode less RWX permissions */
+  m &= ALLPERMS;     /* new RWX permissions */
 
-	return m | mode;
+  return m | mode;
 }

--- a/tools/compat/lchmod.c
+++ b/tools/compat/lchmod.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: lchmod.c,v 1.4 2008/04/28 20:24:12 martin Exp $	*/
-
 /*-
  * Copyright (c) 2002 The NetBSD Foundation, Inc.
  * All rights reserved.
@@ -37,20 +35,18 @@
 #endif /* !defined(__minix) && !defined(_LIBC) */
 
 #if !HAVE_LCHMOD
-#include <sys/stat.h>
 #include <errno.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
-int
-lchmod(const char *path, mode_t mode)
-{
-	struct stat psb;
+int lchmod(const char *path, mode_t mode) {
+  struct stat psb;
 
-	if (lstat(path, &psb) == -1)
-		return -1;
-	if (S_ISLNK(psb.st_mode)) {
-		return 0;
-	}
-	return (chmod(path, mode));
+  if (lstat(path, &psb) == -1)
+    return -1;
+  if (S_ISLNK(psb.st_mode)) {
+    return 0;
+  }
+  return (chmod(path, mode));
 }
 #endif

--- a/tools/compat/pread.c
+++ b/tools/compat/pread.c
@@ -1,5 +1,3 @@
-/*	$NetBSD: pread.c,v 1.4 2008/04/28 20:24:12 martin Exp $	*/
-
 /*-
  * Copyright (c) 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
@@ -37,19 +35,19 @@
 #include <unistd.h>
 
 ssize_t pread(int d, void *buf, size_t nbytes, off_t offset) {
-	off_t oldoff = lseek(d, offset, SEEK_SET);
-	int olderrno;
-	ssize_t nr;
+  off_t oldoff = lseek(d, offset, SEEK_SET);
+  int olderrno;
+  ssize_t nr;
 
-	if (oldoff < 0)
-		return -1;
+  if (oldoff < 0)
+    return -1;
 
-	nr = read(d, buf, nbytes);
+  nr = read(d, buf, nbytes);
 
-	olderrno = errno;
-	lseek(d, oldoff, SEEK_SET);
-	errno = olderrno;
+  olderrno = errno;
+  lseek(d, oldoff, SEEK_SET);
+  errno = olderrno;
 
-	return nr;
+  return nr;
 }
 #endif


### PR DESCRIPTION
## Summary
- trim `NetBSD` RCS identifiers from a few `tools/compat` sources
- run clang-format on edited code for modern style

## Testing
- `make -n` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_683a96e8593c833193b4fac7ca1c04c3