### PR TITLE
Clean NetBSD references from csh

### DIFF
--- a/bin/csh/Makefile
+++ b/bin/csh/Makefile
@@ -1,4 +1,3 @@
-#	$NetBSD: Makefile,v 1.41 2014/07/05 23:12:33 dholland Exp $
 #	@(#)Makefile	8.1 (Berkeley) 5/31/93
 #
 # C Shell with process control; VM/UNIX VAX Makefile

--- a/bin/csh/USD.doc/Makefile
+++ b/bin/csh/USD.doc/Makefile
@@ -1,4 +1,3 @@
-#	$NetBSD: Makefile,v 1.9 2014/07/05 19:22:41 dholland Exp $
 #	@(#)Makefile	8.1 (Berkeley) 8/14/93
 
 SECTION=reference/ref1

--- a/bin/csh/USD.doc/csh.1
+++ b/bin/csh/USD.doc/csh.1
@@ -1,4 +1,3 @@
-.\"	$NetBSD: csh.1,v 1.5 2003/08/07 09:05:08 agc Exp $
 .\"
 .\" Copyright (c) 1980, 1993
 .\"	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/USD.doc/csh.2
+++ b/bin/csh/USD.doc/csh.2
@@ -1,4 +1,3 @@
-.\"	$NetBSD: csh.2,v 1.7 2003/08/07 09:05:08 agc Exp $
 .\"
 .\" Copyright (c) 1980, 1993
 .\"	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/USD.doc/csh.3
+++ b/bin/csh/USD.doc/csh.3
@@ -1,4 +1,3 @@
-.\"	$NetBSD: csh.3,v 1.5 2003/08/07 09:05:08 agc Exp $
 .\"
 .\" Copyright (c) 1980, 1993
 .\"	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/USD.doc/csh.4
+++ b/bin/csh/USD.doc/csh.4
@@ -1,4 +1,3 @@
-.\"	$NetBSD: csh.4,v 1.4 2003/08/07 09:05:08 agc Exp $
 .\"
 .\" Copyright (c) 1980, 1993
 .\"	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/USD.doc/csh.ap
+++ b/bin/csh/USD.doc/csh.ap
@@ -1,4 +1,3 @@
-.\"	$NetBSD: csh.ap,v 1.1 2007/10/18 18:26:31 tls Exp $
 .\"
 .\" Copyright (c) 1980, 1993
 .\"	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/USD.doc/csh.g
+++ b/bin/csh/USD.doc/csh.g
@@ -1,4 +1,3 @@
-.\"	$NetBSD: csh.g,v 1.5 2003/08/07 09:05:08 agc Exp $
 .\"
 .\" Copyright (c) 1980, 1993
 .\"	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/USD.doc/tabs
+++ b/bin/csh/USD.doc/tabs
@@ -1,4 +1,3 @@
-.\"	$NetBSD: tabs,v 1.4 2003/08/07 09:05:09 agc Exp $
 .\"
 .\" Copyright (c) 1980, 1993
 .\"	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/alloc.c
+++ b/bin/csh/alloc.c
@@ -1,5 +1,3 @@
-/* $NetBSD: alloc.c,v 1.13 2013/01/22 19:28:00 christos Exp $ */
-
 /*-
  * Copyright (c) 1983, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)alloc.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: alloc.c,v 1.13 2013/01/22 19:28:00 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/char.c
+++ b/bin/csh/char.c
@@ -1,5 +1,3 @@
-/* $NetBSD: char.c,v 1.10 2012/01/19 02:42:53 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)char.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: char.c,v 1.10 2012/01/19 02:42:53 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/char.h
+++ b/bin/csh/char.h
@@ -1,5 +1,3 @@
-/* $NetBSD: char.h,v 1.9 2012/01/19 02:42:53 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -83,7 +81,6 @@ extern unsigned char _cmap_lower[], _cmap_upper[];
 #define Isalnum(c)	(((c) & QUOTE) ? 0 : isalnum((unsigned char) (c)))
 #define Iscntrl(c) 	(((c) & QUOTE) ? 0 : iscntrl((unsigned char) (c)))
 #define Isprint(c) 	(((c) & QUOTE) ? 0 : isprint((unsigned char) (c)))
-#else
 #define Isspace(c)	cmap(c, _SP|_NL)
 #define Isdigit(c)	cmap(c, _DIG)
 #define Isalpha(c)	(cmap(c,_LET) && !(((c) & META) && AsciiOnly))

--- a/bin/csh/const.c
+++ b/bin/csh/const.c
@@ -1,5 +1,3 @@
-/* $NetBSD: const.c,v 1.10 2013/01/22 20:35:29 christos Exp $ */
-
 /*-
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)const.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: const.c,v 1.10 2013/01/22 20:35:29 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/csh.1
+++ b/bin/csh/csh.1
@@ -1,4 +1,3 @@
-.\"	$NetBSD: csh.1,v 1.53 2016/08/10 17:16:47 sevan Exp $
 .\"
 .\" Copyright (c) 1980, 1990, 1993
 .\"	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/csh.c
+++ b/bin/csh/csh.c
@@ -1,5 +1,3 @@
-/* $NetBSD: csh.c,v 1.46 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -38,8 +36,6 @@ __COPYRIGHT("@(#) Copyright (c) 1980, 1991, 1993\
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)csh.c	8.2 (Berkeley) 10/12/93";
-#else
-__RCSID("$NetBSD: csh.c,v 1.46 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 
@@ -185,7 +181,6 @@ main(int argc, char *argv[])
 	    continue;
 	AsciiOnly = k > 0377;
     }
-#else
     AsciiOnly = getenv("LANG") == NULL && getenv("LC_CTYPE") == NULL;
 #endif				/* NLS */
 
@@ -257,7 +252,6 @@ main(int argc, char *argv[])
     if ((ecp = getenv("PATH")) == NULL) {
 #ifdef _PATH_DEFPATH
 	importpath(str2short(_PATH_DEFPATH));
-#else
 	setq(STRpath, defaultpath(), &shvhed);
 #endif
     } else {
@@ -1304,7 +1298,6 @@ initdesc(void)
 __dead void
 #ifdef PROF
 done(int i)
-#else
 xexit(int i)
 #endif
 {

--- a/bin/csh/csh.h
+++ b/bin/csh/csh.h
@@ -1,5 +1,3 @@
-/* $NetBSD: csh.h,v 1.26 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -66,7 +64,6 @@
 typedef short Char;
 
 #define SAVE(a) (Strsave(str2short(a)))
-#else
 typedef char Char;
 
 #define SAVE(a) (strsave(a))
@@ -207,7 +204,6 @@ sig_t parterm;			/* Parents terminate catch */
 #define	CHAR ((Char)0xff)
 #define	QUOTE ((Char)0x8000)	/* 16nth char bit used for 'ing */
 #define	TRIM ((Char)0x7fff)	/* Mask to strip quote bit */
-#else
 #define	CHAR ((Char)0x7f)
 #define	QUOTE ((Char)0x80)	/* Eighth char bit used for 'ing */
 #define	TRIM ((Char)0x7f)	/* Mask to strip quote bit */
@@ -501,7 +497,6 @@ Char HISTSUB;			/* auto-substitute character */
 #define blk2short(a)		saveblk(a)
 #define short2blk(a)		saveblk(a)
 #define short2str(a)		strip(a)
-#else
 #define Strchr(a, b)		s_strchr(a, b)
 #define Strrchr(a, b)		s_strrchr(a, b)
 #define Strcat(a, b)		s_strcat(a, b)

--- a/bin/csh/dir.c
+++ b/bin/csh/dir.c
@@ -1,5 +1,3 @@
-/* $NetBSD: dir.c,v 1.30 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)dir.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: dir.c,v 1.30 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/dir.h
+++ b/bin/csh/dir.h
@@ -1,5 +1,3 @@
-/* $NetBSD: dir.h,v 1.8 2003/08/07 09:05:04 agc Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/dol.c
+++ b/bin/csh/dol.c
@@ -1,5 +1,3 @@
-/* $NetBSD: dol.c,v 1.29 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)dol.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: dol.c,v 1.29 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/err.c
+++ b/bin/csh/err.c
@@ -1,5 +1,3 @@
-/* $NetBSD: err.c,v 1.21 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)err.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: err.c,v 1.21 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/exec.c
+++ b/bin/csh/exec.c
@@ -1,5 +1,3 @@
-/* $NetBSD: exec.c,v 1.29 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)exec.c	8.3 (Berkeley) 5/23/95";
-#else
-__RCSID("$NetBSD: exec.c,v 1.29 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/exp.c
+++ b/bin/csh/exp.c
@@ -1,5 +1,3 @@
-/* $NetBSD: exp.c,v 1.20 2009/02/14 07:12:29 lukem Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)exp.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: exp.c,v 1.20 2009/02/14 07:12:29 lukem Exp $");
 #endif
 #endif /* not lint */
 
@@ -518,7 +514,6 @@ exp6(Char ***vp, int ignore)
 	    case 'l':
 #ifdef S_ISLNK
 		i = S_ISLNK(stb.st_mode);
-#else
 		i = 0;
 #endif
 		break;
@@ -528,14 +523,12 @@ exp6(Char ***vp, int ignore)
 	    case 'p':
 #ifdef S_ISFIFO
 		i = S_ISFIFO(stb.st_mode);
-#else
 		i = 0;
 #endif
 		break;
 	    case 's':
 #ifdef S_ISSOCK
 		i = S_ISSOCK(stb.st_mode);
-#else
 		i = 0;
 #endif
 		break;

--- a/bin/csh/extern.h
+++ b/bin/csh/extern.h
@@ -1,5 +1,3 @@
-/* $NetBSD: extern.h,v 1.29 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -58,7 +56,6 @@ int vis_fputc(int, FILE *);
 
 #ifdef PROF
 __dead void done(int);
-#else
 __dead void xexit(int);
 #endif
 

--- a/bin/csh/file.c
+++ b/bin/csh/file.c
@@ -1,5 +1,3 @@
-/* $NetBSD: file.c,v 1.30 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)file.c	8.2 (Berkeley) 3/19/94";
-#else
-__RCSID("$NetBSD: file.c,v 1.30 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/func.c
+++ b/bin/csh/func.c
@@ -1,5 +1,3 @@
-/* $NetBSD: func.c,v 1.40 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)func.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: func.c,v 1.40 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 
@@ -951,7 +947,6 @@ dosetenv(Char **v, struct command *t)
 	for (k = 0200; k <= 0377 && !Isprint(k); k++)
 		continue;
 	AsciiOnly = k > 0377;
-#else
 	AsciiOnly = 0;
 #endif				/* NLS */
     }
@@ -997,7 +992,6 @@ dounsetenv(Char **v, struct command *t)
 		    for (k = 0200; k <= 0377 && !Isprint(k); k++)
 			continue;
 		    AsciiOnly = k > 0377;
-#else
 		    AsciiOnly = getenv("LANG") == NULL &&
 			getenv("LC_CTYPE") == NULL;
 #endif				/* NLS */

--- a/bin/csh/glob.c
+++ b/bin/csh/glob.c
@@ -1,5 +1,3 @@
-/* $NetBSD: glob.c,v 1.27 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)glob.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: glob.c,v 1.27 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 
@@ -916,7 +912,6 @@ sortscmp(const ptr_t a, const ptr_t b)
 #if defined(NLS) && !defined(NOSTRCOLL)
     (void)strcpy(buf, short2str(*(Char **)a));
     return ((int)strcoll(buf, short2str(*(Char **)b)));
-#else
     return ((int)Strcmp(*(Char **)a, *(Char **)b));
 #endif
 }

--- a/bin/csh/hist.c
+++ b/bin/csh/hist.c
@@ -1,5 +1,3 @@
-/* $NetBSD: hist.c,v 1.20 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)hist.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: hist.c,v 1.20 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/init.c
+++ b/bin/csh/init.c
@@ -1,5 +1,3 @@
-/* $NetBSD: init.c,v 1.11 2013/01/22 19:28:00 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)init.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: init.c,v 1.11 2013/01/22 19:28:00 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/lex.c
+++ b/bin/csh/lex.c
@@ -1,5 +1,3 @@
-/* $NetBSD: lex.c,v 1.31 2013/08/06 05:42:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)lex.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: lex.c,v 1.31 2013/08/06 05:42:43 christos Exp $");
 #endif
 #endif /* not lint */
 
@@ -1528,7 +1524,6 @@ again:
 	feobp += c;
 #ifndef FILEC
 	goto again;
-#else
 	if (filec && !intty)
 	    goto again;
 #endif

--- a/bin/csh/misc.c
+++ b/bin/csh/misc.c
@@ -1,5 +1,3 @@
-/* $NetBSD: misc.c,v 1.20 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)misc.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: misc.c,v 1.20 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/parse.c
+++ b/bin/csh/parse.c
@@ -1,5 +1,3 @@
-/* $NetBSD: parse.c,v 1.17 2007/07/16 18:26:10 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)parse.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: parse.c,v 1.17 2007/07/16 18:26:10 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/pathnames.h
+++ b/bin/csh/pathnames.h
@@ -1,5 +1,3 @@
-/* $NetBSD: pathnames.h,v 1.8 2003/08/07 09:05:06 agc Exp $ */
-
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/proc.c
+++ b/bin/csh/proc.c
@@ -1,5 +1,3 @@
-/* $NetBSD: proc.c,v 1.36 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)proc.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: proc.c,v 1.36 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/proc.h
+++ b/bin/csh/proc.h
@@ -1,5 +1,3 @@
-/* $NetBSD: proc.h,v 1.14 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/bin/csh/sem.c
+++ b/bin/csh/sem.c
@@ -1,5 +1,3 @@
-/* $NetBSD: sem.c,v 1.29 2011/08/29 14:51:17 joerg Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)sem.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: sem.c,v 1.29 2011/08/29 14:51:17 joerg Exp $");
 #endif
 #endif /* not lint */
 
@@ -578,7 +574,6 @@ doio(struct command *t, int *pipein, int *pipeout)
 	if ((flags & F_APPEND) &&
 #ifdef O_APPEND
 	    (fd = open(tmp, O_WRONLY | O_APPEND)) >= 0);
-#else
 	    (fd = open(tmp, O_WRONLY)) >= 0)
 	    (void)lseek(1, (off_t) 0, SEEK_END);
 #endif

--- a/bin/csh/set.c
+++ b/bin/csh/set.c
@@ -1,5 +1,3 @@
-/* $NetBSD: set.c,v 1.33 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)set.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: set.c,v 1.33 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 
@@ -668,7 +664,6 @@ exportpath(Char **val)
 	((p)->v_right = t->v_left) ? (t->v_left->v_parent = (p)) : 0,\
 	(t->v_left = (p))->v_parent = t,\
 	(p) = t)
-#else
 struct varent *
 rleft(struct varent *p)
 {

--- a/bin/csh/str.c
+++ b/bin/csh/str.c
@@ -1,5 +1,3 @@
-/* $NetBSD: str.c,v 1.15 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)str.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: str.c,v 1.15 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 

--- a/bin/csh/time.c
+++ b/bin/csh/time.c
@@ -1,5 +1,3 @@
-/* $NetBSD: time.c,v 1.20 2013/07/16 17:47:43 christos Exp $ */
-
 /*-
  * Copyright (c) 1980, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +31,6 @@
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)time.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: time.c,v 1.20 2013/07/16 17:47:43 christos Exp $");
 #endif
 #endif /* not lint */
 


### PR DESCRIPTION
## Summary
- remove NetBSD headers and RCSIDs from `bin/csh` sources
- drop RCSID lines from csh documentation

## Testing
- `make` *(fails: `Makefile:8: *** missing separator. Stop.`)*

------
https://chatgpt.com/codex/tasks/task_e_683a96c66d648331b2284974cb8d6ec5