### PR TITLE
Remove NetBSD strings from sync

### DIFF
--- a/bin/sync/Makefile
+++ b/bin/sync/Makefile
@@ -1,4 +1,3 @@
-#	$NetBSD: Makefile,v 1.9 1997/07/20 22:38:07 christos Exp $
 #	@(#)Makefile	8.1 (Berkeley) 5/31/93
 
 PROG=	sync

--- a/bin/sync/sync.8
+++ b/bin/sync/sync.8
@@ -1,5 +1,3 @@
-.\"	$NetBSD: sync.8,v 1.16 2016/08/12 02:59:23 sevan Exp $
-.\"
 .\" Copyright (c) 1980, 1991, 1993
 .\"	The Regents of the University of California.  All rights reserved.
 .\"

--- a/bin/sync/sync.c
+++ b/bin/sync/sync.c
@@ -1,5 +1,3 @@
-/* $NetBSD: sync.c,v 1.14 2016/09/05 01:00:07 sevan Exp $ */
-
 /*
  * Copyright (c) 1987, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -35,23 +33,18 @@ __COPYRIGHT("@(#) Copyright (c) 1987, 1993\
  The Regents of the University of California.  All rights reserved.");
 #endif /* not lint */
 
-#ifndef lint
-#if 0
-static char sccsid[] = "@(#)sync.c	8.1 (Berkeley) 5/31/93";
-#else
-__RCSID("$NetBSD: sync.c,v 1.14 2016/09/05 01:00:07 sevan Exp $");
-#endif
-#endif /* not lint */
-
 #include <stdlib.h>
 #include <unistd.h>
 
 /* ARGSUSED */
-int
-main(int argc, char *argv[])
-{
-	setprogname(argv[0]);
-	sync();
-	exit(0);
-	/* NOTREACHED */
+int main(int argc, char *argv[]) {
+  /* register program name for messages */
+  setprogname(argv[0]);
+
+  /* flush all file system buffers */
+  sync();
+
+  /* terminate successfully */
+  return EXIT_SUCCESS;
+  /* NOTREACHED */
 }


### PR DESCRIPTION
## Summary
- purge NetBSD version tags from `bin/sync`
- modernize `sync.c` with comments and return value

## Testing
- `clang -Wall -Wextra -std=c11 -c bin/sync/sync.c` *(fails: expected parameter declarator)*


------
https://chatgpt.com/codex/tasks/task_e_683a96ecbb7883318c1ef1fe89759829