### PR TITLE
Add test and fix build flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,18 @@ modern documentation.
   when possible.
 
 These rules apply to the entire repository.
+
+## Development Tools Setup
+
+The project expects a modern LLVM toolchain. Verify package availability and
+install the following tools using `apt`:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y clang-18 clang-tools-18 llvm-18-dev \
+  libpolly-18-dev lld-18 lldb-18 bolt-18 build-essential binutils \
+  meson valgrind lcov
+```
+
+Update this list as new major versions (e.g., `clang-19`) become available.
+Check with `apt-cache policy` before changing versions.

--- a/meson.build
+++ b/meson.build
@@ -3,8 +3,16 @@
 project(
     'minix',
     'c',
-    default_options: ['c_std=c11']
 )
+
+# Detect C23 support and adjust the compilation standard accordingly.
+cc = meson.get_compiler('c')
+if cc.has_argument('-std=c23')
+  add_project_arguments('-std=c23', language: 'c')
+else
+  # Fall back to C17 when the compiler lacks C23 support.
+  add_project_arguments('-std=c17', language: 'c')
+endif
 
 # Select the build architecture.
 arch = get_option('arch')

--- a/minix/kernel/meson.build
+++ b/minix/kernel/meson.build
@@ -1,15 +1,4 @@
 # meson.build - Complete kernel build configuration for MINIX
-project('minix-kernel', 'c',
-    version: '3.4.1-unofficial',
-    license: 'BSD-mixed',
-    default_options: [
-        'c_std=c23', // Changed to c23 to match capability libs, or ensure compatibility
-        'warning_level=3',
-        'b_staticpic=false',
-        'b_pie=false',
-        'b_lto=false',
-    ]
-)
 
 cc = meson.get_compiler('c')
 arch = host_machine.cpu_family()
@@ -54,9 +43,9 @@ endif
 kernel_includes = include_directories(
     'include',
     'include/arch/' + arch_subdir,
-    'klib/include', // Existing klib includes
+    'klib/include',  # Existing klib includes
     '.',
-    'capability' // For headers like capability_syscalls.h in minix/kernel/capability
+    'capability'  # For headers like capability_syscalls.h in minix/kernel/capability
 )
 
 # Existing Kernel library (klib)
@@ -73,7 +62,7 @@ kernel_capability_sources = [
     'capability/capability_proof.c',
     'capability/capability_verify.c',
     'capability/math_syscalls.c',
-    'capability/math_syscalls_extended.c', // Added this line
+    'capability/math_syscalls_extended.c',  # Added this line
     'capability/capability_audit.c',
     'capability/capability_cache.c'
 ]
@@ -82,8 +71,8 @@ kernel_capability_sources = [
 kernel_capability_lib = static_library('kernel_capability',
     kernel_capability_sources,
     include_directories: kernel_includes, # Uses the same kernel_includes, which now includes 'capability' subdir
-    c_args: kernel_c_args + ['-DMATHEMATICAL_VERIFICATION'], // Add specific defines if any, like from issue
-    dependencies: [capability_klib_dep], // Depend on our new capability_klib
+    c_args: kernel_c_args + ['-DMATHEMATICAL_VERIFICATION'],  # Add specific defines if any, like from issue
+    dependencies: [capability_klib_dep],  # Depend on our new capability_klib
     install: false
 )
 
@@ -169,10 +158,10 @@ mdlm_sources = []
 if option_enable_mdlm
     # When MDLM source files are created, they will be added here:
     mdlm_sources += files(
-        'mdlm_cap_dag.c'       // MDLM Capability DAG component
-    #    'mdlm/thread_lattice.c', // Example future file
-    #    'mdlm/cap_dag.c',        // Example future file (Note: user plan had this, might be a typo for proc_dag.c)
-    #    'mdlm/security_lattice.c'// Example future file
+        'mdlm_cap_dag.c'        # MDLM Capability DAG component
+    #    'mdlm/thread_lattice.c', /Example future file
+    #    'mdlm/cap_dag.c',        /Example future file (Note: user plan had this, might be a typo for proc_dag.c)
+    #    'mdlm/security_lattice.c'/Example future file
     )
     message('MDLM sources enabled: mdlm_cap_dag.c') # Updated message
 endif

--- a/minix/lib/klib/meson.build
+++ b/minix/lib/klib/meson.build
@@ -1,5 +1,4 @@
 # minix/lib/klib/meson.build
-project('capability_klib', 'c') // Renamed project
 
 klib_sources = [
     'src/kmemory_c23.c',
@@ -13,21 +12,19 @@ klib_sources = [
 
 klib_include_dirs = include_directories('include')
 
-capability_klib = static_library('capability_klib', // Renamed library
+capability_klib = static_library('capability_klib', # Renamed library
     klib_sources,
     include_directories: klib_include_dirs,
-    c_args: ['-std=c23', '-DKERNEL_SPACE', '-DKDEBUG',
+    c_args: ['-DKERNEL_SPACE', '-DKDEBUG',
              '-DMATHEMATICAL_VERIFICATION']
-    # pic: false // Explicitly false if this lib is kernel only and won't be linked to user space directly
+    # pic: false  # Explicitly false if this lib is kernel only and won't be linked to user space directly
 )
 
-capability_klib_dep = declare_dependency( // Renamed dependency variable
+capability_klib_dep = declare_dependency( # Renamed dependency variable
     include_directories: klib_include_dirs,
     link_with: capability_klib
 )
 
-project('klib', 'c',
-  default_options : ['warning_level=2', 'c_std=c23'])
 
 # Common C arguments for klib
 klib_c_args = [
@@ -67,6 +64,3 @@ klib_dep = declare_dependency(
   include_directories : klib_inc
 )
 
-# For subproject access if klib_inc is needed directly by the parent project
-# This makes 'klib_include_dir' available via klib_proj.get_variable()
-meson.override_variable('klib_include_dir', klib_inc)

--- a/minix/lib/libc/meson.build
+++ b/minix/lib/libc/meson.build
@@ -1,18 +1,17 @@
 # minix/lib/libc/meson.build
-project('minix_libc', 'c')
 
 libc_include_dirs = include_directories(
-    '.',                            // For internal libc headers if any
-    '../../include',                // For <mathposix.h>, <minix/ipc.h>, <minix/callnr.h> etc.
-                                    // Adjust if mathposix.h is in minix/include/minix/
-    '../../include/posix'           // If POSIX headers like <sys/types.h> are there
+    '.',                              # For internal libc headers if any
+    '../../include',                  # For <mathposix.h>, <minix/ipc.h>, <minix/callnr.h> etc.
+                                      # Adjust if mathposix.h is in minix/include/minix/
+    '../../include/posix'             # If POSIX headers like <sys/types.h> are there
 )
 
 libc_sources = files(
-    'sys-minix/mathematical_posix.c', // Moved in previous step
-    'sys-minix/mathematical_init.c', // Added this line
-    'sys-minix/math_control.c'        // Will be created in a future step
-    // Other libc sources would be listed here in a full libc build
+    'sys-minix/mathematical_posix.c',   # Moved in previous step
+    'sys-minix/mathematical_init.c',   # Added this line
+    'sys-minix/math_control.c'          # Will be created in a future step
+    # Other libc sources would be listed here in a full libc build
 )
 
 # Compiler arguments for libc (might differ from kernel)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/basic.test.js",
     "jscpd": "jscpd",
     "jscpd:run": "node scripts/run-jscpd.js"
   },

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+function add(a, b) {
+  return a + b;
+}
+
+assert.strictEqual(add(1, 2), 3);
+console.log('basic test passed');


### PR DESCRIPTION
## Summary
- auto-detect C23 support in `meson.build`
- clean meson files and remove invalid project calls
- add a basic Node.js test and hook it up in `package.json`

## Testing
- `sudo apt-get update`
- `sudo apt-get -y install --no-install-recommends clang-18 clang-tools-18 lld-18 lldb-18 llvm-18-dev libpolly-18-dev bolt-18 build-essential binutils meson valgrind lcov`
- `clang-18 --version`
- `meson --version`
- `npm test`
- `rm -rf build && CC=clang-18 meson setup build` *(fails: missing subproject)*
- `ninja -C build` *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_684acc3a60088331b214b15862da3800