### PR TITLE
Add Doxygen docs for DAG scheduler

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -901,7 +901,7 @@ WARN_IF_UNDOC_ENUM_VAL = NO
 # Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -943,7 +943,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = minix/kernel/k_spinlock.h
+INPUT                  = minix/kernel/dag.h minix/kernel/dag_sched.c
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -982,55 +982,55 @@ INPUT_FILE_ENCODING    =
 # provided as doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
 
-                         *.cc \
-                         *.cxx \
-                         *.cxxm \
-                         *.cpp \
-                         *.cppm \
-                         *.c++ \
-                         *.c++m \
-                         *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.idl \
-                         *.ddl \
-                         *.odl \
-                         *.h \
-                         *.hh \
-                         *.hxx \
-                         *.hpp \
-                         *.h++ \
-                         *.ixx \
-                         *.l \
-                         *.cs \
-                         *.d \
-                         *.php \
-                         *.php4 \
-                         *.php5 \
-                         *.phtml \
-                         *.inc \
-                         *.m \
-                         *.markdown \
-                         *.md \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.pyw \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f18 \
-                         *.f \
-                         *.for \
-                         *.vhd \
-                         *.vhdl \
-                         *.ucf \
-                         *.qsf \
-                         *.ice
+#                          *.cc \
+#                          *.cxx \
+#                          *.cxxm \
+#                          *.cpp \
+#                          *.cppm \
+#                          *.c++ \
+#                          *.c++m \
+#                          *.java \
+#                          *.ii \
+#                          *.ixx \
+#                          *.ipp \
+#                          *.i++ \
+#                          *.inl \
+#                          *.idl \
+#                          *.ddl \
+#                          *.odl \
+#                          *.h \
+#                          *.hh \
+#                          *.hxx \
+#                          *.hpp \
+#                          *.h++ \
+#                          *.ixx \
+#                          *.l \
+#                          *.cs \
+#                          *.d \
+#                          *.php \
+#                          *.php4 \
+#                          *.php5 \
+#                          *.phtml \
+#                          *.inc \
+#                          *.m \
+#                          *.markdown \
+#                          *.md \
+#                          *.mm \
+#                          *.dox \
+#                          *.py \
+#                          *.pyw \
+#                          *.f90 \
+#                          *.f95 \
+#                          *.f03 \
+#                          *.f08 \
+#                          *.f18 \
+#                          *.f \
+#                          *.for \
+#                          *.vhd \
+#                          *.vhdl \
+#                          *.ucf \
+#                          *.qsf \
+#                          *.ice
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/minix/kernel/dag.h
+++ b/minix/kernel/dag.h
@@ -4,28 +4,72 @@
 
 struct dag_node;
 
+/**
+ * @brief Linked list element for DAG nodes.
+ */
 struct dag_node_list {
-  struct dag_node *node;
-  struct dag_node_list *next;
+  struct dag_node *node; /**< Child node in the list. */
+  struct dag_node_list *next; /**< Next element in the list. */
 };
 
+/**
+ * @brief Node representing a schedulable unit in the DAG scheduler.
+ */
 struct dag_node {
-  exo_cap ctx;
-  int pending;
-  int priority;
-  int weight;
-  struct dag_node_list *children;
-  struct dag_node *next;
-  struct dag_node **deps;
-    int ndeps;
-    int done;
-
+  exo_cap ctx;                    /**< Execution context capability. */
+  int pending;                    /**< Number of unfinished dependencies. */
+  int priority;                   /**< Scheduling priority. */
+  int weight;                     /**< Relative weight used for ordering. */
+  struct dag_node_list *children; /**< List of dependent child nodes. */
+  struct dag_node *next;          /**< Next node in internal queues. */
+  struct dag_node **deps;         /**< Array of dependency pointers. */
+  int ndeps;                      /**< Number of entries in @c deps. */
+  int done;                       /**< Flag set once the node has run. */
 };
 
+/**
+ * @brief Initialize a DAG node with an execution context.
+ *
+ * @param n   Node to initialize.
+ * @param ctx Execution context capability.
+ */
 void dag_node_init(struct dag_node *n, exo_cap ctx);
+
+/**
+ * @brief Set the scheduling priority for a node.
+ *
+ * @param n        Node to update.
+ * @param priority Priority value.
+ */
 void dag_node_set_priority(struct dag_node *n, int priority);
+
+/**
+ * @brief Set the relative weight for a node.
+ *
+ * @param n      Node to update.
+ * @param weight Weight used when ordering nodes.
+ */
 void dag_node_set_weight(struct dag_node *n, int weight);
+
+/**
+ * @brief Declare a dependency between two nodes.
+ *
+ * @param parent Node that must finish first.
+ * @param child  Node that depends on @p parent.
+ */
 void dag_node_add_dep(struct dag_node *parent, struct dag_node *child);
-void dag_sched_submit(struct dag_node *node);
+
+/**
+ * @brief Submit a node to the DAG scheduler.
+ *
+ * Nodes with no pending dependencies are added to the ready queue.
+ *
+ * @param n Node to submit.
+ */
+void dag_sched_submit(struct dag_node *n);
+
+/**
+ * @brief Initialize the DAG scheduler subsystem.
+ */
 void dag_sched_init(void);
 


### PR DESCRIPTION
## Summary
- document DAG scheduler structs and functions
- store docs in header and implementation files
- enable warnings-as-errors for Doxygen
- limit documentation to scheduler sources
- fix previous invalid example list in Doxyfile

## Testing
- `apt-get update`
- `apt-get install -y doxygen graphviz`
- `doxygen -q Doxyfile` *(fails: More #endif's than #if's in spinlock.h)*

------
https://chatgpt.com/codex/tasks/task_e_684ac75a55b0833197cc9af1af4db2f5