### PR TITLE
Introduce canonical kalloc allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Oichkatzelesfrettschen/minix318)
+
+## Building with Meson and Ninja
+
+The project uses the Meson build system. A minimal configuration relies on the
+LLVM toolchain and `ninja` for compilation:
+
+```bash
+export CC=clang-18
+export CFLAGS="-O3 -pthread -fopenmp -Werror"
+meson setup build
+ninja -C build
+```
+
+This configuration ensures all kernel sources are compiled with modern LLVM
+optimizations and strict warning enforcement.

--- a/docs/dev-build-requirements.md
+++ b/docs/dev-build-requirements.md
@@ -39,6 +39,22 @@ The following Debian/Ubuntu packages are installed:
 - nodejs
 - npm
 
+## Minimal build configuration
+
+The kernel and supporting libraries are compiled with `clang`. The
+recommended flags ensure reproducible behavior across architectures:
+
+```bash
+export CC=clang-18
+export CFLAGS="-O3 -pthread -fopenmp -Werror"
+meson setup build
+ninja -C build
+```
+
+The `-O3`, `-pthread`, and `-fopenmp` flags enable high optimization and
+parallelism while `-Werror` promotes warnings to errors to maintain code
+quality.
+
 ## Node dependencies
 
 After the system packages are installed, `npm ci` installs the Node-based developer tools defined in `package.json`. Currently this includes the `jscpd` copy/paste detector.

--- a/malloc.c
+++ b/malloc.c
@@ -1,6 +1,17 @@
+/**
+ * @file malloc.c
+ * @brief Legacy memory allocator now forwarded to kalloc.
+ *
+ * The original implementation is preserved below and disabled.
+ */
+#include <kalloc.h>
+#if 0
 /* Copyright (c) 1979 Regents of the University of California */
 #ifdef debug
-#define ASSERT(p) if(!(p))botch("p");else
+#define ASSERT(p)                                                              \
+  if (!(p))                                                                    \
+    botch("p");                                                                \
+  else
 botch(s)
 char *s;
 {
@@ -39,12 +50,12 @@ char *s;
 #define ALIGN int
 #define NALIGN 1
 #define WORD sizeof(union store)
-#define BLOCK 1024	/* a multiple of WORD*/
+#define BLOCK 1024 /* a multiple of WORD*/
 #define BUSY 1
 #define NULL 0
-#define testbusy(p) ((INT)(p)&BUSY)
-#define setbusy(p) (union store *)((INT)(p)|BUSY)
-#define clearbusy(p) (union store *)((INT)(p)&~BUSY)
+#define testbusy(p) ((INT)(p) & BUSY)
+#define setbusy(p) (union store *)((INT)(p) | BUSY)
+#define clearbusy(p) (union store *)((INT)(p) & ~BUSY)
 
 union store { union store *ptr;
 	      ALIGN dummy[NALIGN];
@@ -188,3 +199,8 @@ allock()
 #endif
 }
 #endif
+#endif /* end legacy implementation */
+
+char *malloc(unsigned nbytes) { return kalloc(nbytes); }
+void free(char *ap) { kfree(ap); }
+char *realloc(char *ptr, unsigned nbytes) { return krealloc(ptr, nbytes); }

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # Meson build configuration for the MINIX project
 # The kernel sources are written in C11 and C23 with C11 --> C23 migration in progress.
 
-project('minix', 'c', default_options : ['c_std=c23'])
+project('minix', 'c', default_options : ['c_std=c2x'])
 # Configure global optimization
 
 # Detect C23 support and adjust the compilation standard accordingly.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,19 +1,23 @@
-# Meson build options for MINIX
+#Meson build options for MINIX
 
-# Select the target architecture for the build.
-option(
-    'arch',
-    type : 'combo',
-    choices : ['i386', 'x86_64', 'arm32', 'arm64'],
-    value : 'i386',
-    description : 'Target architecture'
-)
+#Select the target architecture for the build.
+option('arch',
+       type : 'combo',
+       choices : ['i386', 'x86_64', 'arm32', 'arm64'],
+       value : 'i386',
+       description : 'Target architecture')
 
-# Generic compilation options
+#Generic compilation options
+option('opt_level',
+       type : 'string',
+       value : '3',
+       description : 'Optimization level used as -O<level>')
 
-option(
-    'opt_level',
-    type : 'string',
-    value : '3',
-    description : 'Optimization level used as -O<level>'
-)
+#Select the C standard for libc's custom math component
+option('libc_c_std',
+       type : 'combo',
+       choices : ['c11', 'c17', 'c23'],
+       value : 'c23',
+       description : 'C standard to use when compiling libc custom math')
+
+

--- a/minix/kernel/meson.build
+++ b/minix/kernel/meson.build
@@ -1,85 +1,207 @@
-```meson
-#------------------------------------------------------------------------------
-# minix/lib/libc/meson.build
-#
-# Builds the custom mathematical‐POSIX extensions to the MINIX C library.
-# Defines a static component 'libc_custom_math' that other parts of the system
-# can link against for math‐verified POSIX functionality.
-#------------------------------------------------------------------------------
+# meson.build - Complete kernel build configuration for MINIX
+# project('minix-kernel', 'c',
+#    version: '3.4.1-unofficial',
+#    license: 'BSD-mixed',
+#    default_options: [
+#        'c_std=c23', # Changed to c23 to match capability libs, or ensure compatibility
+#        'warning_level=3',
+#        'b_staticpic=false',
+#        'b_pie=false',
+#        'b_lto=false',
+#    ]
+# )
 
-#------------------------------------------------------------------------------  
-# Options  
-#------------------------------------------------------------------------------  
-# Allow overriding the C standard for this component (default: C11)
-option(
-  'libc_c_std',
-  type        : 'string',
-  value       : 'c23',
-  choices     : ['c11', 'c17', 'c23'],
-  description : 'C standard to use when compiling libc custom math'
+cc = meson.get_compiler('c')
+# arch = host_machine.cpu_family()  # use arch option from parent project
+if arch == 'x86_64'
+    arch_subdir = 'x86_64'
+    arch_defines = ['-D__x86_64__', '-DARCH_X86_64']
+    arch_flags = ['-m64', '-mcmodel=kernel', '-mno-red-zone', '-sse', '-sse2', '-fpu', '-mmx', '-fno-omit-frame-pointer', '-fno-optimize-sibling-calls']
+elif arch == 'x86' or arch == 'i386'
+    arch_subdir = 'i386'
+    arch_defines = ['-D__i386__', '-DARCH_I386']
+    arch_flags = ['-m32', '-fno-omit-frame-pointer', '-fno-optimize-sibling-calls']
+else
+    error('Unsupported architecture: ' + arch)
+endif
+
+kernel_common_flags = ['-ffreestanding', '-fno-builtin', '-fno-stack-protector', '-nostdinc', '-nostdlib', '-Wall', '-Wextra', '-Wno-unused-parameter', '-Wno-missing-field-initializers', '-O' + get_option('opt_level')]
+kernel_c_args = kernel_common_flags + arch_flags + arch_defines
+kernel_link_args = arch_flags
+
+# Get dependency for capability_klib (defined in minix/lib/klib/meson.build)
+# This assumes minix/meson.build called subdir('lib/klib') and exposes capability_klib_dep
+# capability_klib_dep = dependency('capability_klib', fallback: ['capability_klib', 'capability_klib_dep'])
+
+# Add build option for profiling
+# option_enable_profiling = get_option('enable_profiling') # Assuming 'enable_profiling' is defined in meson_options.txt
+# if option_enable_profiling
+#     add_project_arguments('-DCONFIG_PROFILING=1', language: 'c')
+#     message('Kernel profiling enabled.')
+# else
+#     message('Kernel profiling disabled.')
+# endif
+
+# Add build option for MDLM
+# option_enable_mdlm = get_option('enable_mdlm') # Assuming 'enable_mdlm' is defined in meson_options.txt
+# if option_enable_mdlm
+#     add_project_arguments('-DCONFIG_MDLM=1', language: 'c')
+#     message('MDLM support enabled.')
+# else
+#     message('MDLM support disabled.')
+# endif
+
+kernel_includes = include_directories(
+    'include',
+    '../include/arch/' + arch_subdir,
+    '../lib/klib/include', # Existing klib includes
+    '.',
+    'capability' # For headers like capability_syscalls.h in minix/kernel/capability
 )
 
-#------------------------------------------------------------------------------  
-# Include Directories  
-#------------------------------------------------------------------------------  
-# - '.'            : internal headers for this component
-# - '../../include': core MINIX libc headers (mathposix.h, ipc.h, callnr.h, etc.)
-# - '../../include/posix': POSIX types & definitions (sys/types.h, unistd.h, ...)
-libc_include_dirs = include_directories(
-  '.',
-  '../../include',
-  '../../include/posix'
+# Existing Kernel library (klib)
+klib_sources = files(
+    'klib/kstring.c',
+    'klib/kmemory.c',
+    'klib/kprintf_stub.c',
+    'klib/kpanic.c'
 )
+klib = static_library('klib', klib_sources, c_args: kernel_c_args, include_directories: kernel_includes, install: false)
 
-#------------------------------------------------------------------------------  
-# Source Files  
-#------------------------------------------------------------------------------  
-# - mathematical_posix.c : POSIX wrappers with formal math verification
-# - mathematical_init.c  : Initialization routines for the math subsystem
-# - math_control.c       : Control interfaces (to be implemented)
-libc_sources = files(
-  'sys-minix/mathematical_posix.c',
-  'sys-minix/mathematical_init.c',
-  'sys-minix/math_control.c'
-)
-
-#------------------------------------------------------------------------------  
-# Compiler Arguments  
-#------------------------------------------------------------------------------  
-# Uses the chosen C standard, enables all warnings as errors, and respects
-# the top‐level optimization level.
-libc_c_args = [
-  '-std=' + get_option('libc_c_std'),
-  '-Wall',
-  '-Wextra',
-  '-Werror',
-  '-O' + get_option('opt_level')
+# NEW: Kernel Capability Library sources
+kernel_capability_sources = [
+    'capability/capability_proof.c',
+    'capability/capability_verify.c',
+    'capability/math_syscalls.c',
+    'capability/math_syscalls_extended.c', # Added this line
+    'capability/capability_audit.c',
+    'capability/capability_cache.c'
 ]
 
-#------------------------------------------------------------------------------  
-# Static Library Definition  
-#------------------------------------------------------------------------------  
-# Builds a static library 'libc_custom_math' for mathematical/POSIX extensions.
-libc_custom_math = static_library(
-  'libc_custom_math',            # library name
-  libc_sources,                  # source files
-  include_directories : libc_include_dirs,
-  c_args              : libc_c_args,
-  install             : true,    # install into userland libc path
-  install_dir         : 'lib'    # adjust to your Minix layout
+# NEW: Kernel Capability Library definition
+kernel_capability_lib = static_library('kernel_capability',
+    kernel_capability_sources,
+    include_directories: kernel_includes, # Uses the same kernel_includes, which now includes 'capability' subdir
+    c_args: kernel_c_args + ['-DMATHEMATICAL_VERIFICATION'], # Add specific defines if any, like from issue
+    dependencies: [capability_klib_dep], # Depend on our new capability_klib
+    install: false
 )
 
-#------------------------------------------------------------------------------  
-# Dependency Object  
-#------------------------------------------------------------------------------  
-# Exposes include paths and link libraries for other Meson subprojects.
-libc_custom_math_dep = declare_dependency(
-  include_directories : libc_include_dirs,
-  link_with           : libc_custom_math
+# Main kernel sources (core)
+kernel_core_sources = files(
+    'clock.c',
+    'cpulocals.c',
+    'debug.c',
+    'interrupt.c',
+    'main.c',
+    'proc.c',
+    'profile.c',
+    'smp.c',
+    'system.c',
+    'table.c',
+    'usermapped_data.c',
+    'utility.c',
+    'watchdog.c',
+    'clhlock.c',    # Generic CLH lock implementation
+    'clh_bkl.c',    # CLH BKL specific instance and initialization
+    'capability.c', # Capability table management
+    'profile.c'     # Profiling framework (already added, ensure it's here)
 )
 
-#------------------------------------------------------------------------------  
-# Build Notice  
-#------------------------------------------------------------------------------  
-message('Configured libc_custom_math with C standard: ' + get_option('libc_c_std'))
-```
+# System call handler sources
+syscall_sources = []
+syscall_files_find_result = run_command('find', 'system', '-maxdepth', '1', '-name', '*.c', '-print', check: true)
+syscall_files_stdout = syscall_files_find_result.stdout().strip()
+if syscall_files_stdout != ''
+    syscall_files = syscall_files_stdout.split('\n')
+    foreach f : syscall_files
+        if f != ''
+            syscall_sources += files(f)
+        endif
+    endforeach
+endif
+
+# Architecture-specific sources
+arch_sources_list = []
+if arch_subdir == 'i386'
+  arch_sources_list = files(
+    'arch/i386/acpi.c',
+    'arch/i386/apic.c',
+    'arch/i386/arch_clock.c',
+    'arch/i386/arch_do_vmctl.c',
+    'arch/i386/arch_reset.c',
+    'arch/i386/arch_smp.c',
+    'arch/i386/arch_system.c',
+    'arch/i386/arch_watchdog.c',
+    'arch/i386/breakpoints.c',
+    'arch/i386/direct_tty_utils.c',
+    'arch/i386/do_iopenable.c',
+    'arch/i386/do_readbios.c',
+    'arch/i386/do_sdevio.c',
+    'arch/i386/exception.c',
+    'arch/i386/i8259.c',
+    'arch/i386/memory.c',
+    'arch/i386/oxpcie.c',
+    'arch/i386/pg_utils.c',
+    'arch/i386/pre_init.c',
+    'arch/i386/protect.c',
+    'arch/i386/usermapped_data_arch.c'
+  )
+elif arch_subdir == 'x86_64'
+  noop_x86_64 = []
+endif
+
+# Define architecture-specific assembly sources
+kernel_asm_sources = []
+if arch == 'i386'
+    kernel_asm_sources = files(
+        'arch/i386/mpx.S',
+        'arch/i386/head.S',
+        'arch/i386/klib.S',
+        'arch/i386/apic_asm.S'
+    )
+elif arch == 'x86_64'
+    kernel_asm_sources = []
+endif
+
+# MDLM sources (initially empty, will be populated in later phases)
+mdlm_sources = []
+# if option_enable_mdlm
+#     # When MDLM source files are created, they will be added here:
+#     mdlm_sources += files(
+#         'mdlm_cap_dag.c'       # MDLM Capability DAG component
+#     #    'mdlm/thread_lattice.c', # Example future file
+#     #    'mdlm/cap_dag.c',        # Example future file (Note: user plan had this, might be a typo for proc_dag.c)
+#     #    'mdlm/security_lattice.c'# Example future file
+#     )
+#     message('MDLM sources enabled: mdlm_cap_dag.c') # Updated message
+# endif
+
+all_c_sources = kernel_core_sources + syscall_sources + arch_sources_list + mdlm_sources
+linker_script = meson.current_source_dir() / 'arch' / arch_subdir / 'kernel.lds'
+if run_command('test', '-f', linker_script, check: false).returncode() != 0
+    error('Linker script not found: ' + linker_script +
+          '. Please ensure it exists for architecture ' + arch_subdir)
+endif
+kernel_link_args += ['-T', linker_script, '-Wl,--build-id=none']
+
+# Build kernel executable
+kernel = executable('kernel',
+    all_c_sources + kernel_asm_sources,
+    link_with: [klib, kernel_capability_lib], # Added kernel_capability_lib here
+    link_args: kernel_link_args,
+    c_args: kernel_c_args,
+    include_directories: kernel_includes,
+    install: true,
+    install_dir: 'boot'
+)
+
+# Output some information
+message('Building MINIX kernel for ' + arch)
+message('Kernel C_ARGS: ' + ' '.join(kernel_c_args))
+message('Kernel LINK_ARGS: ' + ' '.join(kernel_link_args))
+message('Linker script: ' + linker_script)
+
+# TODO: Add handling for assembly files (.S)
+# TODO: Add custom targets for things like procoffsets.cf if needed
+# TODO: Define what to do if x86_64 sources are missing (e.g. error or allow empty build)

--- a/minix/lib/klib/include/kalloc.h
+++ b/minix/lib/klib/include/kalloc.h
@@ -1,0 +1,35 @@
+#ifndef _MINIX_KALLOC_H
+#define _MINIX_KALLOC_H
+
+#include <klib.h> /* for k_size_t */
+
+/**
+ * @brief Allocate a block of memory from the kernel heap.
+ *
+ * The current implementation forwards to the C library's @c malloc.
+ * A dedicated kernel heap manager may replace this in the future.
+ *
+ * @param size Number of bytes to allocate.
+ * @return Pointer to allocated memory or NULL on failure.
+ */
+void *kalloc(k_size_t size);
+
+/**
+ * @brief Free memory previously allocated with kalloc.
+ *
+ * @param ptr Pointer to memory to free. May be NULL.
+ */
+void kfree(void *ptr);
+
+/**
+ * @brief Resize an allocation obtained from kalloc.
+ *
+ * This behaves similar to @c realloc.
+ *
+ * @param ptr  Existing allocation or NULL for a new block.
+ * @param size New size in bytes.
+ * @return Pointer to resized block or NULL on failure.
+ */
+void *krealloc(void *ptr, k_size_t size);
+
+#endif /* _MINIX_KALLOC_H */

--- a/minix/lib/klib/include/klib.h
+++ b/minix/lib/klib/include/klib.h
@@ -427,6 +427,11 @@ void kdebug_print(const char *fmt, ...); /* For debug-only messages */
 /* CPU feature detection function */
 void kcpu_detect_features(void);
 
+/* Memory allocation */
+void *kalloc(k_size_t size);
+void kfree(void *ptr);
+void *krealloc(void *ptr, k_size_t size);
+
 #endif /* _KLIB_H */
 #ifndef MINIX_KLIB_H
 #define MINIX_KLIB_H

--- a/minix/lib/klib/meson.build
+++ b/minix/lib/klib/meson.build
@@ -62,11 +62,12 @@ capability_klib_dep = declare_dependency(
 # Sources for the core kernel support library
 core_klib_sources = [
   'src/kmemory_c23.c',                   
-  'src/kstring_c23.c',                   
-  'src/kcore.c',                         
-  'src/kconv.c',                         
-  'src/kdebug.c',                        
-  'src/kcapability_dag.c',               
+  'src/kstring_c23.c',
+  'src/kcore.c',
+  'src/kconv.c',
+  'src/kdebug.c',
+  'src/kalloc.c',
+  'src/kcapability_dag.c',
   'src/kassert_metrics.c',               
   'arch/i386/kcpu_detect_features_arch.c'
 ]

--- a/minix/lib/klib/src/kalloc.c
+++ b/minix/lib/klib/src/kalloc.c
@@ -1,0 +1,41 @@
+/**
+ * @file kalloc.c
+ * @brief Canonical kernel memory allocator.
+ *
+ * This implementation currently defers to the host C library's
+ * @c malloc(), @c free() and @c realloc() functions. The interface
+ * is kept separate so that future kernel-specific allocators can be
+ * dropped in transparently.
+ */
+
+#include <kalloc.h>
+#include <klib.h>
+#include <stdlib.h>
+
+/**
+ * @brief Allocate memory from the kernel heap.
+ *
+ * The current implementation is a thin wrapper around the standard
+ * @c malloc() function. It enables a future drop-in replacement
+ * without impacting call sites.
+ *
+ * @param size Number of bytes to allocate.
+ * @return Pointer to allocated memory or @c NULL on failure.
+ */
+void *kalloc(k_size_t size) { return malloc(size); }
+
+/**
+ * @brief Release memory obtained with kalloc().
+ *
+ * @param ptr Allocation to free. May be @c NULL.
+ */
+void kfree(void *ptr) { free(ptr); }
+
+/**
+ * @brief Resize a block allocated by kalloc().
+ *
+ * @param ptr  Existing allocation or @c NULL for a new block.
+ * @param size Desired new size in bytes.
+ * @return Pointer to resized block or @c NULL on failure.
+ */
+void *krealloc(void *ptr, k_size_t size) { return realloc(ptr, size); }

--- a/minix/lib/libc/meson.build
+++ b/minix/lib/libc/meson.build
@@ -5,16 +5,10 @@
 #------------------------------------------------------------------------------
 
 #------------------------------------------------------------------------------  
-# Options  
-#------------------------------------------------------------------------------  
-# Choose the C standard for this component: c11, c17 or c23
-option(
-  'libc_c_std',
-  type        : 'string',
-  value       : 'c23',
-  choices     : ['c11', 'c17', 'c23'],
-  description : 'C standard to use when compiling libc custom math'
-)
+# Build options
+#------------------------------------------------------------------------------
+# The C standard for this component is controlled by the top-level
+# 'libc_c_std' option declared in meson_options.txt.
 
 #------------------------------------------------------------------------------  
 # Include Directories  
@@ -24,8 +18,7 @@ option(
 # - '../../include/posix': POSIX types & definitions (sys/types.h, unistd.h, ...)
 libc_include_dirs = include_directories(
   '.',
-  '../../include',
-  '../../include/posix'
+  '../../include'
 )
 
 #------------------------------------------------------------------------------  


### PR DESCRIPTION
## Summary
- add a small canonical allocator in `klib`
- expose `kalloc`, `kfree`, and `krealloc` through new header
- integrate `kalloc.c` into `klib` build
- forward legacy `malloc.c` to use `kalloc`
- document kalloc implementation
- adjust Meson project C standard to `c2x`
- fix Meson options file and build scripts so `meson setup` succeeds
- document minimal clang/ninja configuration

## Testing
- `meson setup build`
- `ninja -C build` *(fails: cc doesn't recognize -std=c23)*


------
https://chatgpt.com/codex/tasks/task_e_684b2bb3752483319998c1523b83b388