### PR TITLE
Refactor _BitInt usage in kcapability mathematical analysis

### DIFF
--- a/minix/lib/klib/src/kcapability_mathematical_analysis.c
+++ b/minix/lib/klib/src/kcapability_mathematical_analysis.c
@@ -8,14 +8,26 @@
  * deep insights into system properties and performance characteristics.
  */
 
-#include "../include/klib.h" // For KASSERT, kprintf (or kprintf_stub)
 #include "../../../kernel/include/minix/kcapability_dag.h" // For kcapability_dag_t and its definitions
+#include "../include/klib.h" // For KASSERT, kprintf (or kprintf_stub)
+#include <stdint.h>
+
+/** Helper macro to define 32-bit wide integer constants. */
+#ifndef WIDE_INT32_C
+#define WIDE_INT32_C(val) UINT32_C(val)
+#endif
+
+/** Helper macro to define 64-bit wide integer constants. */
+#ifndef WIDE_INT64_C
+#define WIDE_INT64_C(val) UINT64_C(val)
+#endif
 
 // Forward declarations for static helper stubs (to be defined in the next step)
-static void analyze_dag_mathematical_structure(kcapability_dag_t* dag);
-static void analyze_capability_performance_mathematics(kcapability_dag_t* dag);
-static void analyze_security_mathematical_guarantees(kcapability_dag_t* dag);
-static void provide_mathematical_optimization_recommendations(kcapability_dag_t* dag);
+static void analyze_dag_mathematical_structure(kcapability_dag_t *dag);
+static void analyze_capability_performance_mathematics(kcapability_dag_t *dag);
+static void analyze_security_mathematical_guarantees(kcapability_dag_t *dag);
+static void
+provide_mathematical_optimization_recommendations(kcapability_dag_t *dag);
 
 /**
  * @brief Analyze mathematical properties of the entire capability system.
@@ -33,28 +45,32 @@ static void provide_mathematical_optimization_recommendations(kcapability_dag_t*
  *      might call validation).
  * @post Analysis results are printed (conceptually) via kprintf.
  */
-void kcapability_analyze_system_mathematical_properties(kcapability_dag_t* dag) {
-    KASSERT(dag != NULL, "kcapability_analyze_system_mathematical_properties: dag is NULL");
+void kcapability_analyze_system_mathematical_properties(
+    kcapability_dag_t *dag) {
+  KASSERT(dag != NULL,
+          "kcapability_analyze_system_mathematical_properties: dag is NULL");
 
-    // It's good practice to validate invariants before detailed analysis.
-    // The user's spec included this KASSERT.
-    KASSERT(dag->validate_invariants(dag), "kcapability_analyze_system_mathematical_properties: DAG invariants failed before analysis");
+  // It's good practice to validate invariants before detailed analysis.
+  // The user's spec included this KASSERT.
+  KASSERT(dag->validate_invariants(dag),
+          "kcapability_analyze_system_mathematical_properties: DAG invariants "
+          "failed before analysis");
 
-    kprintf_stub("=== Mathematical Analysis of Capability System ===\n");
+  kprintf_stub("=== Mathematical Analysis of Capability System ===\n");
 
-    /* Analyze basic mathematical properties */
-    analyze_dag_mathematical_structure(dag);
+  /* Analyze basic mathematical properties */
+  analyze_dag_mathematical_structure(dag);
 
-    /* Analyze performance characteristics through mathematical lens */
-    analyze_capability_performance_mathematics(dag);
+  /* Analyze performance characteristics through mathematical lens */
+  analyze_capability_performance_mathematics(dag);
 
-    /* Analyze security properties through mathematical verification */
-    analyze_security_mathematical_guarantees(dag);
+  /* Analyze security properties through mathematical verification */
+  analyze_security_mathematical_guarantees(dag);
 
-    /* Provide optimization recommendations based on mathematical analysis */
-    provide_mathematical_optimization_recommendations(dag);
+  /* Provide optimization recommendations based on mathematical analysis */
+  provide_mathematical_optimization_recommendations(dag);
 
-    kprintf_stub("=== Mathematical Analysis Complete ===\n");
+  kprintf_stub("=== Mathematical Analysis Complete ===\n");
 }
 
 // Stub implementations for helper functions (to be defined in the next step)
@@ -71,96 +87,122 @@ void kcapability_analyze_system_mathematical_properties(kcapability_dag_t* dag) 
  *
  * @pre dag must not be NULL.
  */
-static void analyze_dag_mathematical_structure(kcapability_dag_t* dag) {
-    KASSERT(dag != NULL, "analyze_dag_structure: dag is NULL");
+static void analyze_dag_mathematical_structure(kcapability_dag_t *dag) {
+  KASSERT(dag != NULL, "analyze_dag_structure: dag is NULL");
 
-    kprintf_stub("--- DAG Mathematical Structure Analysis ---\n");
-    kprintf_stub("Node Count: %llu, Edge Count: %llu, Node Capacity: %u\n",
-                 (unsigned long long)dag->node_count,
-                 (unsigned long long)dag->edge_count,
-                 (unsigned int)dag->node_capacity);
+  kprintf_stub("--- DAG Mathematical Structure Analysis ---\n");
+  kprintf_stub("Node Count: %llu, Edge Count: %llu, Node Capacity: %u\n",
+               (unsigned long long)dag->node_count,
+               (unsigned long long)dag->edge_count,
+               (unsigned int)dag->node_capacity);
 
-    bool invariants_hold = dag->validate_invariants(dag);
-    kprintf_stub("DAG Invariants Hold: %s\n", invariants_hold ? "TRUE" : "FALSE");
+  bool invariants_hold = dag->validate_invariants(dag);
+  kprintf_stub("DAG Invariants Hold: %s\n", invariants_hold ? "TRUE" : "FALSE");
 
-    if (!invariants_hold) {
-        kprintf_stub("WARNING: DAG invariants do not hold! Further analysis might be unreliable.\n");
-        // Optionally, could return here or limit further output if invariants failed.
-    }
+  if (!invariants_hold) {
+    kprintf_stub("WARNING: DAG invariants do not hold! Further analysis might "
+                 "be unreliable.\n");
+    // Optionally, could return here or limit further output if invariants
+    // failed.
+  }
 
-    // Print info for the first few nodes (e.g., up to 5 or actual count if less)
-    _BitInt(32) nodes_to_print = dag->node_count < 5wb ? dag->node_count : 5wb;
-    kprintf_stub("First %llu nodes (if any):\n", (unsigned long long)nodes_to_print);
+  // Print info for the first few nodes (e.g., up to 5 or actual count if less)
+  uint32_t nodes_to_print =
+      (uint32_t)(dag->node_count < WIDE_INT32_C(5) ? dag->node_count
+                                                   : WIDE_INT32_C(5));
+  kprintf_stub("First %llu nodes (if any):\n",
+               (unsigned long long)nodes_to_print);
 
-    for (_BitInt(32) i = 0wb; i < nodes_to_print; i++) {
-        const kcapability_dag_node_t* node = &dag->nodes[i];
-        // Assume kprintf_stub can handle printing _BitInt or they are cast.
-        // Using unsigned long long for printing _BitInt values.
-        kprintf_stub("  Node %llu: ID=%llu, Rights=%016llX, SecLvl=%u, Children=%u, Parents=%u, Name='%s'\n",
-                     (unsigned long long)i,
-                     (unsigned long long)node->capability_id,
-                     (unsigned long long)node->rights_mask,
-                     (unsigned int)node->security_level,
-                     (unsigned int)node->child_count,
-                     (unsigned int)node->parent_count,
-                     node->name // Assumes name is null-terminated
-                     );
-    }
-    if (dag->node_count == 0wb) {
-        kprintf_stub("  (No nodes in DAG to display)\n");
-    }
-    kprintf_stub("--- End of DAG Structure Analysis ---\n");
+  for (uint32_t i = WIDE_INT32_C(0); i < nodes_to_print; ++i) {
+    const kcapability_dag_node_t *node = &dag->nodes[i];
+    // Assume kprintf_stub can handle printing _BitInt or they are cast.
+    // Using unsigned long long for printing _BitInt values.
+    kprintf_stub("  Node %llu: ID=%llu, Rights=%016llX, SecLvl=%u, "
+                 "Children=%u, Parents=%u, Name='%s'\n",
+                 (unsigned long long)i, (unsigned long long)node->capability_id,
+                 (unsigned long long)node->rights_mask,
+                 (unsigned int)node->security_level,
+                 (unsigned int)node->child_count,
+                 (unsigned int)node->parent_count,
+                 node->name // Assumes name is null-terminated
+    );
+  }
+  if (dag->node_count == WIDE_INT32_C(0)) {
+    kprintf_stub("  (No nodes in DAG to display)\n");
+  }
+  kprintf_stub("--- End of DAG Structure Analysis ---\n");
 }
 
 /**
  * @brief Analyzes and prints performance statistics of the DAG.
  *
  * This function provides a conceptual overview of the DAG's performance
- * characteristics by printing the values stored in its performance_stats structure.
+ * characteristics by printing the values stored in its performance_stats
+ * structure.
  *
- * @param dag Pointer to the kcapability_dag_t whose performance is to be analyzed.
+ * @param dag Pointer to the kcapability_dag_t whose performance is to be
+ * analyzed.
  *
  * @pre dag must not be NULL.
  */
-static void analyze_capability_performance_mathematics(kcapability_dag_t* dag) {
-    KASSERT(dag != NULL, "analyze_capability_performance: dag is NULL");
+static void analyze_capability_performance_mathematics(kcapability_dag_t *dag) {
+  KASSERT(dag != NULL, "analyze_capability_performance: dag is NULL");
 
-    kprintf_stub("--- DAG Performance Mathematics Analysis ---\n");
+  kprintf_stub("--- DAG Performance Mathematics Analysis ---\n");
 
-    // Assuming kprintf_stub can handle _BitInt or they are cast appropriately.
-    // Using unsigned long long for printing _BitInt(64) values.
-    kprintf_stub("Total Operations: %llu\n", (unsigned long long)dag->performance_stats.operations_total);
-    kprintf_stub("Cache Hits (conceptual): %llu\n", (unsigned long long)dag->performance_stats.cache_hits);
-    kprintf_stub("Cache Misses (conceptual): %llu\n", (unsigned long long)dag->performance_stats.cache_misses);
-    kprintf_stub("Successful Derivations: %llu\n", (unsigned long long)dag->performance_stats.successful_derivations);
-    kprintf_stub("Failed Derivations: %llu\n", (unsigned long long)dag->performance_stats.failed_derivations);
-    kprintf_stub("Traversals (conceptual): %llu\n", (unsigned long long)dag->performance_stats.traversals);
+  // Assuming kprintf_stub can handle _BitInt or they are cast appropriately.
+  // Using unsigned long long for printing _BitInt(64) values.
+  kprintf_stub("Total Operations: %llu\n",
+               (unsigned long long)dag->performance_stats.operations_total);
+  kprintf_stub("Cache Hits (conceptual): %llu\n",
+               (unsigned long long)dag->performance_stats.cache_hits);
+  kprintf_stub("Cache Misses (conceptual): %llu\n",
+               (unsigned long long)dag->performance_stats.cache_misses);
+  kprintf_stub(
+      "Successful Derivations: %llu\n",
+      (unsigned long long)dag->performance_stats.successful_derivations);
+  kprintf_stub("Failed Derivations: %llu\n",
+               (unsigned long long)dag->performance_stats.failed_derivations);
+  kprintf_stub("Traversals (conceptual): %llu\n",
+               (unsigned long long)dag->performance_stats.traversals);
 
-    // Conceptual: Calculate and print hit/miss ratio if counts are significant
-    _BitInt(64) total_lookups = dag->performance_stats.cache_hits + dag->performance_stats.cache_misses;
-    if (total_lookups > 0wb) {
-        // For printing float/percentage, kprintf_stub might not support it.
-        // Conceptual print:
-        unsigned long long hit_ratio_percent = 0;
-        if (dag->performance_stats.cache_hits > 0wb) { // Avoid division by zero if total_lookups is also 0
-             hit_ratio_percent = (unsigned long long)((dag->performance_stats.cache_hits * 100wb) / total_lookups);
-        }
-        kprintf_stub("Conceptual Lookup Hit Ratio: %llu %%\n", hit_ratio_percent);
-    } else {
-        kprintf_stub("Conceptual Lookup Hit Ratio: N/A (no lookups recorded)\n");
+  // Conceptual: Calculate and print hit/miss ratio if counts are significant
+  uint64_t total_lookups = (uint64_t)(dag->performance_stats.cache_hits +
+                                      dag->performance_stats.cache_misses);
+  if (total_lookups > WIDE_INT64_C(0)) {
+    // For printing float/percentage, kprintf_stub might not support it.
+    // Conceptual print:
+    unsigned long long hit_ratio_percent = 0;
+    if (dag->performance_stats.cache_hits >
+        WIDE_INT64_C(0)) { // Avoid division by zero if total_lookups is also 0
+      hit_ratio_percent =
+          (unsigned long long)((dag->performance_stats.cache_hits *
+                                WIDE_INT64_C(100)) /
+                               total_lookups);
     }
+    kprintf_stub("Conceptual Lookup Hit Ratio: %llu %%\n", hit_ratio_percent);
+  } else {
+    kprintf_stub("Conceptual Lookup Hit Ratio: N/A (no lookups recorded)\n");
+  }
 
-    kprintf_stub("--- End of DAG Performance Analysis ---\n");
+  kprintf_stub("--- End of DAG Performance Analysis ---\n");
 }
 
-static void analyze_security_mathematical_guarantees(kcapability_dag_t* dag) {
-    kprintf_stub("STUB: analyze_security_mathematical_guarantees called for DAG %p\n", (void*)dag);
-    // KASSERT(0, "STUB: analyze_security_mathematical_guarantees"); // Commented out for now
-    (void)dag;
+static void analyze_security_mathematical_guarantees(kcapability_dag_t *dag) {
+  kprintf_stub(
+      "STUB: analyze_security_mathematical_guarantees called for DAG %p\n",
+      (void *)dag);
+  // KASSERT(0, "STUB: analyze_security_mathematical_guarantees"); // Commented
+  // out for now
+  (void)dag;
 }
 
-static void provide_mathematical_optimization_recommendations(kcapability_dag_t* dag) {
-    kprintf_stub("STUB: provide_mathematical_optimization_recommendations called for DAG %p\n", (void*)dag);
-    // KASSERT(0, "STUB: provide_mathematical_optimization_recommendations"); // Commented out for now
-    (void)dag;
+static void
+provide_mathematical_optimization_recommendations(kcapability_dag_t *dag) {
+  kprintf_stub("STUB: provide_mathematical_optimization_recommendations called "
+               "for DAG %p\n",
+               (void *)dag);
+  // KASSERT(0, "STUB: provide_mathematical_optimization_recommendations"); //
+  // Commented out for now
+  (void)dag;
 }


### PR DESCRIPTION
## Summary
- replace `_BitInt` variables with standard integers
- add macros `WIDE_INT32_C` and `WIDE_INT64_C` for wide constants
- remove `wb` constant suffixes
- format file with `clang-format`

## Testing
- `clang-format -i minix/lib/klib/src/kcapability_mathematical_analysis.c`
- `make -n` *(fails: missing separator)*
- `meson setup build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b624ed7648331b7c159dcad8008b7