### PR TITLE
Fix legacy shift operators

### DIFF
--- a/subr.c
+++ b/subr.c
@@ -116,7 +116,7 @@ calloc(num, size)
 	if ((p1 = alloc(nbyte)) == -1 || p1==0)
 		return (-1);
 	p2 = p1;
-	nbyte =>> 1;		/* 2 bytes/word */
+	nbyte >>= 1; /* 2 bytes/word */
 	do {
 		*p2++ = 0;
 	} while (--nbyte);
@@ -196,8 +196,8 @@ opush(c)
 {
 
 	c =- 'a';
-	optstk[c] =<< 1;
-	optstk[c] =| opts[c];
+	optstk[c] <<= 1;
+	optstk[c] |= opts[c];
 	opts[c] = 1;
 #ifdef PI0
 	send(ROPUSH, c);
@@ -210,7 +210,7 @@ opop(c)
 
 	c =- 'a';
 	opts[c] = optstk[c] & 1;
-	optstk[c] =>> 1;
+	optstk[c] >>= 1;
 #ifdef PI0
 	send(ROPOP, c);
 #endif


### PR DESCRIPTION
## Summary
- modernize subr.c by using `<<=`, `>>=`, and `|=`
- keep historical layout and run clang-format on edited lines

## Testing
- `node test/basic.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684b62400e1c8331a32969afe215cb6b

## Summary by Sourcery

Update subr.c to use standard C shift and bitwise assignment operators and reformat modified lines

Enhancements:
- Replace legacy operators =>> , =<< and =| with standard >>= , <<= and |= in subr.c

Chores:
- Run clang-format on edited lines to maintain code layout