### PR TITLE
Fix duplicate definitions in demos

### DIFF
--- a/dag_demo.c
+++ b/dag_demo.c
@@ -1,24 +1,27 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include "libos/exo-userland.h"
 #include "libos/sched.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-typedef struct exo_cap { uint32_t pa; } exo_cap;
-
-struct dag_node { int pending; int priority; };
+struct dag_node {
+  int pending;
+  int priority;
+};
 
 static void dag_node_init(struct dag_node *n, exo_cap ctx) {
-  (void)ctx; n->pending = 0; n->priority = 0;
+  (void)ctx;
+  n->pending = 0;
+  n->priority = 0;
 }
 static void dag_node_add_dep(struct dag_node *parent, struct dag_node *child) {
-  (void)parent; (void)child;
+  (void)parent;
+  (void)child;
 }
 static void dag_sched_submit(struct dag_node *node) {
   printf("dag_sched_submit priority %d\n", node->priority);
 }
-static void exo_stream_yield(void) {
-  printf("exo_stream_yield called\n");
-}
+static void exo_stream_yield(void) { printf("exo_stream_yield called\n"); }
 
 static struct dag_node a, b, c;
 
@@ -38,7 +41,8 @@ static void setup(void) {
 }
 
 int main(int argc, char *argv[]) {
-  (void)argc; (void)argv;
+  (void)argc;
+  (void)argv;
   printf("DAG scheduler demo\n");
   setup();
   exo_stream_yield();

--- a/exo_stream_demo.c
+++ b/exo_stream_demo.c
@@ -1,13 +1,9 @@
-#include <stdio.h>
-#include <stdint.h>
-#include "spinlock.h"
-#include "exo_stream.h"
 #include "defs.h"
-
-typedef struct exo_cap {
-  uint32_t pa;
-  uint32_t id;
-} exo_cap;
+#include "exo_stream.h"
+#include "libos/exo-userland.h"
+#include "spinlock.h"
+#include <stdint.h>
+#include <stdio.h>
 
 // Minimal stub implementations used when kernel support is absent.
 int exo_yield_to(exo_cap *target) {
@@ -44,39 +40,6 @@ void streams_yield(void) {
   exo_stream_yield();
   yield();
 }
-
-int main(int argc, char **argv) {
-  (void)argc;
-  (void)argv;
-  exo_cap other = {0, 42};
-  exo_yield_to(&other);
-  exo_yield_to_demo(other);
-  streams_yield();
-  streams_stop();
-  return 0;
-}
-#include <stdio.h>
-#include <stdint.h>
-
-typedef struct exo_cap {
-  uint32_t pa;
-  uint32_t id;
-} exo_cap;
-
-// Minimal stub implementations used when kernel support is absent.
-int exo_yield_to(exo_cap *target) {
-  printf("exo_yield_to called with cap %u\n", target->id);
-  return 0;
-}
-
-// Simple user-level demonstration for exo_yield_to
-int exo_yield_to_demo(exo_cap target) {
-  printf(1, "exo_yield_to called with cap %p\n", (void *)target.id);
-  return 0;
-}
-
-void streams_stop(void) { printf("streams_stop called\n"); }
-void streams_yield(void) { printf("streams_yield called\n"); }
 
 int main(int argc, char **argv) {
   (void)argc;

--- a/libos/exo_unit_test.c
+++ b/libos/exo_unit_test.c
@@ -1,80 +1,65 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
+#include "exo-userland.h"
 #include <assert.h>
-
-typedef uint32_t uint32_t;
-
-typedef struct exo_cap {
-    uint32_t pa;
-    uint32_t id;
-    uint32_t rights;
-    uint32_t owner;
-} exo_cap;
-
-typedef struct exo_blockcap {
-    uint32_t dev;
-    uint32_t blockno;
-    uint32_t rights;
-    uint32_t owner;
-} exo_blockcap;
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
 static uint32_t next_page = 1;
 static uint32_t next_block = 1;
 static unsigned char diskbuf[512];
 
 exo_cap exo_alloc_page(void) {
-    exo_cap cap;
-    cap.pa = next_page * 0x1000;
-    cap.id = next_page++;
-    cap.rights = 0;
-    cap.owner = 1;
-    return cap;
+  exo_cap cap;
+  cap.pa = next_page * 0x1000;
+  cap.id = next_page++;
+  cap.rights = 0;
+  cap.owner = 1;
+  return cap;
 }
 
 int exo_unbind_page(exo_cap cap) {
-    (void)cap;
-    return 0;
+  (void)cap;
+  return 0;
 }
 
 int exo_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap) {
-    cap->dev = dev;
-    cap->blockno = next_block++;
-    cap->rights = rights;
-    cap->owner = 1;
-    return 0;
+  cap->dev = dev;
+  cap->blockno = next_block++;
+  cap->rights = rights;
+  cap->owner = 1;
+  return 0;
 }
 
 int exo_bind_block(exo_blockcap *cap, void *data, int write) {
-    (void)cap;
-    if (write)
-        memcpy(diskbuf, data, sizeof(diskbuf));
-    else
-        memcpy(data, diskbuf, sizeof(diskbuf));
-    return 0;
+  (void)cap;
+  if (write)
+    memcpy(diskbuf, data, sizeof(diskbuf));
+  else
+    memcpy(data, diskbuf, sizeof(diskbuf));
+  return 0;
 }
 
 static void test_exo_pages(void) {
-    exo_cap cap = exo_alloc_page();
-    assert(cap.pa != 0);
-    assert(exo_unbind_page(cap) == 0);
+  exo_cap cap = exo_alloc_page();
+  assert(cap.pa != 0);
+  assert(exo_unbind_page(cap) == 0);
 }
 
 static void test_exo_block(void) {
-    exo_blockcap blk;
-    assert(exo_alloc_block(1, 3, &blk) == 0);
-    unsigned char buf[512];
-    memset(buf, 0xab, sizeof(buf));
-    assert(exo_bind_block(&blk, buf, 1) == 0);
-    memset(buf, 0, sizeof(buf));
-    assert(exo_bind_block(&blk, buf, 0) == 0);
-    for (size_t i = 0; i < sizeof(buf); i++)
-        assert(buf[i] == 0xab);
+  exo_blockcap blk;
+  assert(exo_alloc_block(1, 3, &blk) == 0);
+  unsigned char buf[512];
+  memset(buf, 0xab, sizeof(buf));
+  assert(exo_bind_block(&blk, buf, 1) == 0);
+  memset(buf, 0, sizeof(buf));
+  assert(exo_bind_block(&blk, buf, 0) == 0);
+  for (size_t i = 0; i < sizeof(buf); i++)
+    assert(buf[i] == 0xab);
 }
 
 int main(void) {
-    test_exo_pages();
-    test_exo_block();
-    printf("exo_unit_test passed\n");
-    return 0;
+  test_exo_pages();
+  test_exo_block();
+  printf("exo_unit_test passed\n");
+  return 0;
 }


### PR DESCRIPTION
## Summary
- unify duplicate exo_stream demo functions
- import canonical exo_cap from exo-userland.h
- cleanup demo unit test

## Testing
- `meson compile -C build` *(fails: conflicting headers in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_684b7062ed5083319f7769be6457ffbd