### PR TITLE
Aggregate ACPI sources with includes

### DIFF
--- a/minix/kernel/acpi_unified.c
+++ b/minix/kernel/acpi_unified.c
@@ -1,1363 +1,2894 @@
 /**
  * @file acpi_unified.c
- * @brief Consolidated ACPI source files for analysis.
+ * @brief Aggregated ACPI source files for unified analysis.
  */
 
 /**
- * @section drivers_power_acpi_acpi_c
+ * @section minix_drivers_power_acpi_acpi_c
  * @brief Original file: minix/drivers/power/acpi/acpi.c
  */
-#include <acpi.h>
-#include <assert.h>
-#include <minix/acpi.h>
-#include <minix/driver.h>
-
-#include "pci.h"
-
-int acpi_enabled;
-struct machine machine;
-
-/* don't know where ACPI tables are, we may need to access any memory */
-static int init_mem_priv(void) {
-  struct minix_mem_range mr;
-
-  mr.mr_base = 0;
-  mr.mr_limit = 0xffffffff;
-
-  return sys_privctl(SELF, SYS_PRIV_ADD_MEM, &mr);
-}
-
-static void set_machine_mode(void) {
-  ACPI_OBJECT arg1;
-  ACPI_OBJECT_LIST args;
-  ACPI_STATUS as;
-
-  arg1.Type = ACPI_TYPE_INTEGER;
-  arg1.Integer.Value = machine.apic_enabled ? 1 : 0;
-  args.Count = 1;
-  args.Pointer = &arg1;
-
-  as = AcpiEvaluateObject(ACPI_ROOT_OBJECT, "_PIC", &args, NULL);
-  /*
-   * We can silently ignore failure as it may not be implemented, ACPI should
-   * provide us with correct information anyway
-   */
-  if (ACPI_SUCCESS(as))
-    printf("ACPI: machine set to %s mode\n",
-           machine.apic_enabled ? "APIC" : "PIC");
-}
-
-static ACPI_STATUS init_acpica(void) {
-  ACPI_STATUS status;
-
-  status = AcpiInitializeSubsystem();
-  if (ACPI_FAILURE(status))
-    return status;
-
-  status = AcpiInitializeTables(NULL, 16, FALSE);
-  if (ACPI_FAILURE(status))
-    return status;
-
-  status = AcpiLoadTables();
-  if (ACPI_FAILURE(status))
-    return status;
-
-  status = AcpiEnableSubsystem(0);
-  if (ACPI_FAILURE(status))
-    return status;
-
-  status = AcpiInitializeObjects(0);
-  if (ACPI_FAILURE(status))
-    return status;
-
-  set_machine_mode();
-
-  pci_scan_devices();
-
-  return AE_OK;
-}
-
-void init_acpi(void) {
-  ACPI_STATUS acpi_err;
-  /* test conditions for acpi */
-  if (sys_getmachine(&machine)) {
-    printf("ACPI: no machine\n");
-    return;
-  }
-  if (machine.acpi_rsdp == 0) {
-    printf("ACPI: no RSDP\n");
-    return;
-  }
-  if (init_mem_priv()) {
-    printf("ACPI: no mem access\n");
-    return;
-  }
-
-  if ((acpi_err = init_acpica()) == AE_OK) {
-    acpi_enabled = 1;
-    printf("ACPI: ACPI enabled\n");
-  } else {
-    acpi_enabled = 0;
-    printf("ACPI: ACPI failed with err %d\n", acpi_err);
-  }
-}
-
-static int sef_cb_init_fresh(int type, sef_init_info_t *info) {
-  int r;
-
-  init_acpi();
-
-  /* Let SEF know about ACPI special cache word. */
-  r = sef_llvm_add_special_mem_region((void *)0xCACACACA, 1,
-                                      "%MMAP_CACHE_WORD");
-  if (r < 0) {
-    printf("acpi: sef_llvm_add_special_mem_region failed %d\n", r);
-  }
-
-  /* XXX To-do: acpi requires custom state transfer handlers for
-   * unions acpi_operand_object and acpi_generic_state (and nested unions)
-   * for generic state transfer to work correctly.
-   */
-
-  return OK;
-}
-
-static void sef_local_startup() {
-  /* Register init callbacks. */
-  sef_setcb_init_fresh(sef_cb_init_fresh);
-  sef_setcb_init_lu(sef_cb_init_fresh);
-  sef_setcb_init_restart(sef_cb_init_fresh);
-
-  /* Let SEF perform startup. */
-  sef_startup();
-}
-
-int main(void) {
-  int err;
-  message m;
-  int ipc_status;
-
-  sef_local_startup();
-
-  for (;;) {
-    err = driver_receive(ANY, &m, &ipc_status);
-    if (err != OK) {
-      printf("ACPI: driver_receive failed: %d\n", err);
-      continue;
-    }
-
-    switch (((struct acpi_request_hdr *)&m)->request) {
-    case ACPI_REQ_GET_IRQ:
-      do_get_irq(&m);
-      break;
-    case ACPI_REQ_MAP_BRIDGE:
-      do_map_bridge(&m);
-      break;
-    default:
-      printf("ACPI: ignoring unsupported request %d "
-             "from %d\n",
-             ((struct acpi_request_hdr *)&m)->request,
-             ((struct acpi_request_hdr *)&m)->m_source);
-    }
-
-    err = ipc_send(m.m_source, &m);
-    if (err != OK) {
-      printf("ACPI: ipc_send failed: %d\n", err);
-    }
-  }
-}
+#include "../drivers/power/acpi/acpi.c"
 
 /**
- * @section kernel_arch_i386_acpi_c
+ * @section minix_drivers_power_acpi_dispatcher_dsargs_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dsargs.c
+ */
+#include "../drivers/power/acpi/dispatcher/dsargs.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dscontrol_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dscontrol.c
+ */
+#include "../drivers/power/acpi/dispatcher/dscontrol.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dsfield_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dsfield.c
+ */
+#include "../drivers/power/acpi/dispatcher/dsfield.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dsinit_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dsinit.c
+ */
+#include "../drivers/power/acpi/dispatcher/dsinit.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dsmethod_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dsmethod.c
+ */
+#include "../drivers/power/acpi/dispatcher/dsmethod.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dsmthdat_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dsmthdat.c
+ */
+#include "../drivers/power/acpi/dispatcher/dsmthdat.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dsobject_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dsobject.c
+ */
+#include "../drivers/power/acpi/dispatcher/dsobject.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dsopcode_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dsopcode.c
+ */
+#include "../drivers/power/acpi/dispatcher/dsopcode.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dsutils_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dsutils.c
+ */
+#include "../drivers/power/acpi/dispatcher/dsutils.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dswexec_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dswexec.c
+ */
+#include "../drivers/power/acpi/dispatcher/dswexec.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dswload_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dswload.c
+ */
+#include "../drivers/power/acpi/dispatcher/dswload.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dswload2_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dswload2.c
+ */
+#include "../drivers/power/acpi/dispatcher/dswload2.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dswscope_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dswscope.c
+ */
+#include "../drivers/power/acpi/dispatcher/dswscope.c"
+
+/**
+ * @section minix_drivers_power_acpi_dispatcher_dswstate_c
+ * @brief Original file: minix/drivers/power/acpi/dispatcher/dswstate.c
+ */
+#include "../drivers/power/acpi/dispatcher/dswstate.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evevent_c
+ * @brief Original file: minix/drivers/power/acpi/events/evevent.c
+ */
+#include "../drivers/power/acpi/events/evevent.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evglock_c
+ * @brief Original file: minix/drivers/power/acpi/events/evglock.c
+ */
+#include "../drivers/power/acpi/events/evglock.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evgpe_c
+ * @brief Original file: minix/drivers/power/acpi/events/evgpe.c
+ */
+#include "../drivers/power/acpi/events/evgpe.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evgpeblk_c
+ * @brief Original file: minix/drivers/power/acpi/events/evgpeblk.c
+ */
+#include "../drivers/power/acpi/events/evgpeblk.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evgpeinit_c
+ * @brief Original file: minix/drivers/power/acpi/events/evgpeinit.c
+ */
+#include "../drivers/power/acpi/events/evgpeinit.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evgpeutil_c
+ * @brief Original file: minix/drivers/power/acpi/events/evgpeutil.c
+ */
+#include "../drivers/power/acpi/events/evgpeutil.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evhandler_c
+ * @brief Original file: minix/drivers/power/acpi/events/evhandler.c
+ */
+#include "../drivers/power/acpi/events/evhandler.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evmisc_c
+ * @brief Original file: minix/drivers/power/acpi/events/evmisc.c
+ */
+#include "../drivers/power/acpi/events/evmisc.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evregion_c
+ * @brief Original file: minix/drivers/power/acpi/events/evregion.c
+ */
+#include "../drivers/power/acpi/events/evregion.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evrgnini_c
+ * @brief Original file: minix/drivers/power/acpi/events/evrgnini.c
+ */
+#include "../drivers/power/acpi/events/evrgnini.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evsci_c
+ * @brief Original file: minix/drivers/power/acpi/events/evsci.c
+ */
+#include "../drivers/power/acpi/events/evsci.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evxface_c
+ * @brief Original file: minix/drivers/power/acpi/events/evxface.c
+ */
+#include "../drivers/power/acpi/events/evxface.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evxfevnt_c
+ * @brief Original file: minix/drivers/power/acpi/events/evxfevnt.c
+ */
+#include "../drivers/power/acpi/events/evxfevnt.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evxfgpe_c
+ * @brief Original file: minix/drivers/power/acpi/events/evxfgpe.c
+ */
+#include "../drivers/power/acpi/events/evxfgpe.c"
+
+/**
+ * @section minix_drivers_power_acpi_events_evxfregn_c
+ * @brief Original file: minix/drivers/power/acpi/events/evxfregn.c
+ */
+#include "../drivers/power/acpi/events/evxfregn.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exconfig_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exconfig.c
+ */
+#include "../drivers/power/acpi/executer/exconfig.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exconvrt_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exconvrt.c
+ */
+#include "../drivers/power/acpi/executer/exconvrt.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_excreate_c
+ * @brief Original file: minix/drivers/power/acpi/executer/excreate.c
+ */
+#include "../drivers/power/acpi/executer/excreate.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exdebug_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exdebug.c
+ */
+#include "../drivers/power/acpi/executer/exdebug.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exdump_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exdump.c
+ */
+#include "../drivers/power/acpi/executer/exdump.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exfield_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exfield.c
+ */
+#include "../drivers/power/acpi/executer/exfield.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exfldio_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exfldio.c
+ */
+#include "../drivers/power/acpi/executer/exfldio.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exmisc_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exmisc.c
+ */
+#include "../drivers/power/acpi/executer/exmisc.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exmutex_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exmutex.c
+ */
+#include "../drivers/power/acpi/executer/exmutex.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exnames_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exnames.c
+ */
+#include "../drivers/power/acpi/executer/exnames.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exoparg1_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exoparg1.c
+ */
+#include "../drivers/power/acpi/executer/exoparg1.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exoparg2_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exoparg2.c
+ */
+#include "../drivers/power/acpi/executer/exoparg2.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exoparg3_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exoparg3.c
+ */
+#include "../drivers/power/acpi/executer/exoparg3.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exoparg6_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exoparg6.c
+ */
+#include "../drivers/power/acpi/executer/exoparg6.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exprep_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exprep.c
+ */
+#include "../drivers/power/acpi/executer/exprep.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exregion_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exregion.c
+ */
+#include "../drivers/power/acpi/executer/exregion.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exresnte_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exresnte.c
+ */
+#include "../drivers/power/acpi/executer/exresnte.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exresolv_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exresolv.c
+ */
+#include "../drivers/power/acpi/executer/exresolv.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exresop_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exresop.c
+ */
+#include "../drivers/power/acpi/executer/exresop.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exstore_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exstore.c
+ */
+#include "../drivers/power/acpi/executer/exstore.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exstoren_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exstoren.c
+ */
+#include "../drivers/power/acpi/executer/exstoren.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exstorob_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exstorob.c
+ */
+#include "../drivers/power/acpi/executer/exstorob.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exsystem_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exsystem.c
+ */
+#include "../drivers/power/acpi/executer/exsystem.c"
+
+/**
+ * @section minix_drivers_power_acpi_executer_exutils_c
+ * @brief Original file: minix/drivers/power/acpi/executer/exutils.c
+ */
+#include "../drivers/power/acpi/executer/exutils.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwacpi_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwacpi.c
+ */
+#include "../drivers/power/acpi/hardware/hwacpi.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwesleep_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwesleep.c
+ */
+#include "../drivers/power/acpi/hardware/hwesleep.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwgpe_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwgpe.c
+ */
+#include "../drivers/power/acpi/hardware/hwgpe.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwpci_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwpci.c
+ */
+#include "../drivers/power/acpi/hardware/hwpci.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwregs_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwregs.c
+ */
+#include "../drivers/power/acpi/hardware/hwregs.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwsleep_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwsleep.c
+ */
+#include "../drivers/power/acpi/hardware/hwsleep.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwtimer_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwtimer.c
+ */
+#include "../drivers/power/acpi/hardware/hwtimer.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwvalid_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwvalid.c
+ */
+#include "../drivers/power/acpi/hardware/hwvalid.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwxface_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwxface.c
+ */
+#include "../drivers/power/acpi/hardware/hwxface.c"
+
+/**
+ * @section minix_drivers_power_acpi_hardware_hwxfsleep_c
+ * @brief Original file: minix/drivers/power/acpi/hardware/hwxfsleep.c
+ */
+#include "../drivers/power/acpi/hardware/hwxfsleep.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsaccess_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsaccess.c
+ */
+#include "../drivers/power/acpi/namespace/nsaccess.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsalloc_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsalloc.c
+ */
+#include "../drivers/power/acpi/namespace/nsalloc.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsarguments_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsarguments.c
+ */
+#include "../drivers/power/acpi/namespace/nsarguments.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsconvert_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsconvert.c
+ */
+#include "../drivers/power/acpi/namespace/nsconvert.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsdump_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsdump.c
+ */
+#include "../drivers/power/acpi/namespace/nsdump.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsdumpdv_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsdumpdv.c
+ */
+#include "../drivers/power/acpi/namespace/nsdumpdv.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nseval_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nseval.c
+ */
+#include "../drivers/power/acpi/namespace/nseval.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsinit_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsinit.c
+ */
+#include "../drivers/power/acpi/namespace/nsinit.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsload_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsload.c
+ */
+#include "../drivers/power/acpi/namespace/nsload.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsnames_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsnames.c
+ */
+#include "../drivers/power/acpi/namespace/nsnames.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsobject_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsobject.c
+ */
+#include "../drivers/power/acpi/namespace/nsobject.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsparse_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsparse.c
+ */
+#include "../drivers/power/acpi/namespace/nsparse.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nspredef_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nspredef.c
+ */
+#include "../drivers/power/acpi/namespace/nspredef.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsprepkg_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsprepkg.c
+ */
+#include "../drivers/power/acpi/namespace/nsprepkg.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsrepair_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsrepair.c
+ */
+#include "../drivers/power/acpi/namespace/nsrepair.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsrepair2_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsrepair2.c
+ */
+#include "../drivers/power/acpi/namespace/nsrepair2.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nssearch_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nssearch.c
+ */
+#include "../drivers/power/acpi/namespace/nssearch.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsutils_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsutils.c
+ */
+#include "../drivers/power/acpi/namespace/nsutils.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nswalk_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nswalk.c
+ */
+#include "../drivers/power/acpi/namespace/nswalk.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsxfeval_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsxfeval.c
+ */
+#include "../drivers/power/acpi/namespace/nsxfeval.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsxfname_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsxfname.c
+ */
+#include "../drivers/power/acpi/namespace/nsxfname.c"
+
+/**
+ * @section minix_drivers_power_acpi_namespace_nsxfobj_c
+ * @brief Original file: minix/drivers/power/acpi/namespace/nsxfobj.c
+ */
+#include "../drivers/power/acpi/namespace/nsxfobj.c"
+
+/**
+ * @section minix_drivers_power_acpi_osminixxf_c
+ * @brief Original file: minix/drivers/power/acpi/osminixxf.c
+ */
+#include "../drivers/power/acpi/osminixxf.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psargs_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psargs.c
+ */
+#include "../drivers/power/acpi/parser/psargs.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psloop_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psloop.c
+ */
+#include "../drivers/power/acpi/parser/psloop.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psobject_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psobject.c
+ */
+#include "../drivers/power/acpi/parser/psobject.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psopcode_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psopcode.c
+ */
+#include "../drivers/power/acpi/parser/psopcode.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psopinfo_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psopinfo.c
+ */
+#include "../drivers/power/acpi/parser/psopinfo.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psparse_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psparse.c
+ */
+#include "../drivers/power/acpi/parser/psparse.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psscope_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psscope.c
+ */
+#include "../drivers/power/acpi/parser/psscope.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_pstree_c
+ * @brief Original file: minix/drivers/power/acpi/parser/pstree.c
+ */
+#include "../drivers/power/acpi/parser/pstree.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psutils_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psutils.c
+ */
+#include "../drivers/power/acpi/parser/psutils.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_pswalk_c
+ * @brief Original file: minix/drivers/power/acpi/parser/pswalk.c
+ */
+#include "../drivers/power/acpi/parser/pswalk.c"
+
+/**
+ * @section minix_drivers_power_acpi_parser_psxface_c
+ * @brief Original file: minix/drivers/power/acpi/parser/psxface.c
+ */
+#include "../drivers/power/acpi/parser/psxface.c"
+
+/**
+ * @section minix_drivers_power_acpi_pci_c
+ * @brief Original file: minix/drivers/power/acpi/pci.c
+ */
+#include "../drivers/power/acpi/pci.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsaddr_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsaddr.c
+ */
+#include "../drivers/power/acpi/resources/rsaddr.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rscalc_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rscalc.c
+ */
+#include "../drivers/power/acpi/resources/rscalc.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rscreate_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rscreate.c
+ */
+#include "../drivers/power/acpi/resources/rscreate.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsdump_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsdump.c
+ */
+#include "../drivers/power/acpi/resources/rsdump.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsdumpinfo_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsdumpinfo.c
+ */
+#include "../drivers/power/acpi/resources/rsdumpinfo.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsinfo_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsinfo.c
+ */
+#include "../drivers/power/acpi/resources/rsinfo.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsio_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsio.c
+ */
+#include "../drivers/power/acpi/resources/rsio.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsirq_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsirq.c
+ */
+#include "../drivers/power/acpi/resources/rsirq.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rslist_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rslist.c
+ */
+#include "../drivers/power/acpi/resources/rslist.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsmemory_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsmemory.c
+ */
+#include "../drivers/power/acpi/resources/rsmemory.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsmisc_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsmisc.c
+ */
+#include "../drivers/power/acpi/resources/rsmisc.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsserial_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsserial.c
+ */
+#include "../drivers/power/acpi/resources/rsserial.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsutils_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsutils.c
+ */
+#include "../drivers/power/acpi/resources/rsutils.c"
+
+/**
+ * @section minix_drivers_power_acpi_resources_rsxface_c
+ * @brief Original file: minix/drivers/power/acpi/resources/rsxface.c
+ */
+#include "../drivers/power/acpi/resources/rsxface.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbdata_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbdata.c
+ */
+#include "../drivers/power/acpi/tables/tbdata.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbfadt_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbfadt.c
+ */
+#include "../drivers/power/acpi/tables/tbfadt.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbfind_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbfind.c
+ */
+#include "../drivers/power/acpi/tables/tbfind.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbinstal_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbinstal.c
+ */
+#include "../drivers/power/acpi/tables/tbinstal.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbprint_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbprint.c
+ */
+#include "../drivers/power/acpi/tables/tbprint.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbutils_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbutils.c
+ */
+#include "../drivers/power/acpi/tables/tbutils.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbxface_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbxface.c
+ */
+#include "../drivers/power/acpi/tables/tbxface.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbxfload_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbxfload.c
+ */
+#include "../drivers/power/acpi/tables/tbxfload.c"
+
+/**
+ * @section minix_drivers_power_acpi_tables_tbxfroot_c
+ * @brief Original file: minix/drivers/power/acpi/tables/tbxfroot.c
+ */
+#include "../drivers/power/acpi/tables/tbxfroot.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utaddress_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utaddress.c
+ */
+#include "../drivers/power/acpi/utilities/utaddress.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utalloc_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utalloc.c
+ */
+#include "../drivers/power/acpi/utilities/utalloc.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utbuffer_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utbuffer.c
+ */
+#include "../drivers/power/acpi/utilities/utbuffer.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utcache_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utcache.c
+ */
+#include "../drivers/power/acpi/utilities/utcache.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utclib_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utclib.c
+ */
+#include "../drivers/power/acpi/utilities/utclib.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utcopy_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utcopy.c
+ */
+#include "../drivers/power/acpi/utilities/utcopy.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utdebug_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utdebug.c
+ */
+#include "../drivers/power/acpi/utilities/utdebug.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utdecode_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utdecode.c
+ */
+#include "../drivers/power/acpi/utilities/utdecode.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utdelete_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utdelete.c
+ */
+#include "../drivers/power/acpi/utilities/utdelete.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_uterror_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/uterror.c
+ */
+#include "../drivers/power/acpi/utilities/uterror.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_uteval_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/uteval.c
+ */
+#include "../drivers/power/acpi/utilities/uteval.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utexcep_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utexcep.c
+ */
+#include "../drivers/power/acpi/utilities/utexcep.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utfileio_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utfileio.c
+ */
+#include "../drivers/power/acpi/utilities/utfileio.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utglobal_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utglobal.c
+ */
+#include "../drivers/power/acpi/utilities/utglobal.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_uthex_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/uthex.c
+ */
+#include "../drivers/power/acpi/utilities/uthex.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utids_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utids.c
+ */
+#include "../drivers/power/acpi/utilities/utids.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utinit_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utinit.c
+ */
+#include "../drivers/power/acpi/utilities/utinit.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utlock_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utlock.c
+ */
+#include "../drivers/power/acpi/utilities/utlock.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utmath_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utmath.c
+ */
+#include "../drivers/power/acpi/utilities/utmath.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utmisc_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utmisc.c
+ */
+#include "../drivers/power/acpi/utilities/utmisc.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utmutex_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utmutex.c
+ */
+#include "../drivers/power/acpi/utilities/utmutex.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utobject_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utobject.c
+ */
+#include "../drivers/power/acpi/utilities/utobject.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utosi_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utosi.c
+ */
+#include "../drivers/power/acpi/utilities/utosi.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utownerid_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utownerid.c
+ */
+#include "../drivers/power/acpi/utilities/utownerid.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utpredef_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utpredef.c
+ */
+#include "../drivers/power/acpi/utilities/utpredef.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utprint_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utprint.c
+ */
+#include "../drivers/power/acpi/utilities/utprint.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utresrc_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utresrc.c
+ */
+#include "../drivers/power/acpi/utilities/utresrc.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utstate_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utstate.c
+ */
+#include "../drivers/power/acpi/utilities/utstate.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utstring_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utstring.c
+ */
+#include "../drivers/power/acpi/utilities/utstring.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_uttrack_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/uttrack.c
+ */
+#include "../drivers/power/acpi/utilities/uttrack.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utuuid_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utuuid.c
+ */
+#include "../drivers/power/acpi/utilities/utuuid.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utxface_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utxface.c
+ */
+#include "../drivers/power/acpi/utilities/utxface.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utxferror_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utxferror.c
+ */
+#include "../drivers/power/acpi/utilities/utxferror.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utxfinit_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utxfinit.c
+ */
+#include "../drivers/power/acpi/utilities/utxfinit.c"
+
+/**
+ * @section minix_drivers_power_acpi_utilities_utxfmutex_c
+ * @brief Original file: minix/drivers/power/acpi/utilities/utxfmutex.c
+ */
+#include "../drivers/power/acpi/utilities/utxfmutex.c"
+
+/**
+ * @section minix_kernel_arch_i386_acpi_c
  * @brief Original file: minix/kernel/arch/i386/acpi.c
  */
-// #include <string.h> // Replaced
-// #include <string.h> // Replaced
-
-#include "acpi.h"
-#include "arch_proto.h"
-
-// Added kernel headers
-#include <klib/include/kmemory.h>
-#include <klib/include/kprintf.h>
-#include <klib/include/kstring.h>
-#include <minix/kernel_types.h>
-
-typedef int((*acpi_read_t)(phys_bytes addr, void *buff,
-                           k_size_t size)); // MODIFIED size_t
-// Added kernel headers
-#include <klib/include/kmemory.h>
-#include <klib/include/kprintf.h>
-#include <klib/include/kstring.h>
-#include <minix/kernel_types.h>
-
-typedef int((*acpi_read_t)(phys_bytes addr, void *buff,
-                           k_size_t size)); // MODIFIED size_t
-
-struct acpi_rsdp acpi_rsdp;
-
-static acpi_read_t read_func;
-
-#define MAX_RSDT 35           /* ACPI defines 35 signatures */
-#define SLP_EN_CODE (1 << 13) /* ACPI SLP_EN_CODE code */
-#define AMI_PACKAGE_OP_CODE (0x12)
-#define AMI_NAME_OP_CODE (0x8)
-#define AMI_BYTE_PREFIX_CODE (0xA)
-#define AMI_PACKAGE_LENGTH_ENCODING_BITS_MASK (0xC0)
-#define AMI_PACKAGE_LENGTH_ENCODING_BITS_SHIFT (6)
-#define AMI_MIN_PACKAGE_LENGTH (1)
-#define AMI_NUM_ELEMENTS_LENGTH (1)
-#define AMI_SLP_TYPA_SHIFT (10)
-#define AMI_SLP_TYPB_SHIFT (10)
-#define AMI_S5_NAME_OP_OFFSET_1 (-1)
-#define AMI_S5_NAME_OP_OFFSET_2 (-2)
-#define AMI_S5_PACKAGE_OP_OFFSET (4)
-#define AMI_S5_PACKET_LENGTH_OFFSET (5)
-
-static struct acpi_rsdt {
-  struct acpi_sdt_header hdr;
-  u32_t data[MAX_RSDT];
-} rsdt;
-
-static struct {
-  char signature[ACPI_SDT_SIGNATURE_LEN + 1];
-  k_size_t length; // MODIFIED size_t
-  k_size_t length; // MODIFIED size_t
-} sdt_trans[MAX_RSDT];
-
-static int sdt_count;
-static u16_t pm1a_cnt_blk = 0;
-static u16_t pm1b_cnt_blk = 0;
-static u16_t slp_typa = 0;
-static u16_t slp_typb = 0;
-
-static int acpi_check_csum(struct acpi_sdt_header *tb,
-                           k_size_t size) // MODIFIED size_t
-    static int acpi_check_csum(struct acpi_sdt_header *tb,
-                               k_size_t size) // MODIFIED size_t
-{
-  u8_t total = 0;
-  k_size_t i; // MODIFIED int to k_size_t for loop consistency with size
-  k_size_t i; // MODIFIED int to k_size_t for loop consistency with size
-  for (i = 0; i < size; i++)
-    total += ((unsigned char *)tb)[i];
-  return total == 0 ? 0 : -1;
-}
-
-static int acpi_check_signature(const char *orig, const char *match) {
-  // MODIFIED strncmp to placeholder
-  return kstrncmp(orig, match, ACPI_SDT_SIGNATURE_LEN);
-}
-
-static u32_t acpi_phys2vir(u32_t p) {
-  if (!vm_running) {
-    DEBUGEXTRA(("acpi: returning 0x%lx as vir addr\n", p));
-    return p;
-  }
-  panic("acpi: can't get virtual address of arbitrary physical address");
-}
-
-static int acpi_phys_copy(phys_bytes phys, void *target,
-                          k_size_t len) // MODIFIED size_t
-    static int acpi_phys_copy(phys_bytes phys, void *target,
-                              k_size_t len) // MODIFIED size_t
-{
-  if (!vm_running) {
-    kmemcpy(target, (void *)phys, len); // MODIFIED
-    kmemcpy(target, (void *)phys, len); // MODIFIED
-    return 0;
-  }
-  panic("can't acpi_phys_copy with vm");
-}
-
-static int acpi_read_sdt_at(phys_bytes addr, struct acpi_sdt_header *tb,
-                            k_size_t size, // MODIFIED size_t
-                            k_size_t size, // MODIFIED size_t
-                            const char *name) {
-  struct acpi_sdt_header hdr;
-
-  /* if 0 is supplied, we only return the size of the table */
-  if (tb == 0) { // NULL might be undefined
-    if (read_func(addr, &hdr, sizeof(struct acpi_sdt_header))) {
-      kprintf_stub("ERROR acpi cannot read %s header\n", name); // MODIFIED
-      kprintf_stub("ERROR acpi cannot read %s header\n", name); // MODIFIED
-      return -1;
-    }
-
-    return hdr.length;
-  }
-
-  if (read_func(addr, tb, sizeof(struct acpi_sdt_header))) {
-    kprintf_stub("ERROR acpi cannot read %s header\n", name); // MODIFIED
-    kprintf_stub("ERROR acpi cannot read %s header\n", name); // MODIFIED
-    return -1;
-  }
-
-  if (acpi_check_signature(tb->signature, name)) {
-    kprintf_stub("ERROR acpi %s signature does not match\n", name); // MODIFIED
-    kprintf_stub("ERROR acpi %s signature does not match\n", name); // MODIFIED
-    return -1;
-  }
-
-  if (size < tb->length) {
-    kprintf_stub("ERROR acpi buffer too small for %s\n", name); // MODIFIED
-    kprintf_stub("ERROR acpi buffer too small for %s\n", name); // MODIFIED
-    return -1;
-  }
-
-  if (read_func(addr, tb,
-                size)) { // size was k_size_t, read_func expects k_size_t
-    kprintf_stub("ERROR acpi cannot read %s\n", name); // MODIFIED
-    if (read_func(addr, tb,
-                  size)) { // size was k_size_t, read_func expects k_size_t
-      kprintf_stub("ERROR acpi cannot read %s\n", name); // MODIFIED
-      return -1;
-    }
-
-    if (acpi_check_csum(tb, tb->length)) { // tb->length is u32_t,
-                                           // acpi_check_csum expects k_size_t
-      kprintf_stub("ERROR acpi %s checksum does not match\n", name); // MODIFIED
-      if (acpi_check_csum(tb, tb->length)) { // tb->length is u32_t,
-                                             // acpi_check_csum expects k_size_t
-        kprintf_stub("ERROR acpi %s checksum does not match\n",
-                     name); // MODIFIED
-        return -1;
-      }
-
-      return tb->length;
-    }
-
-    phys_bytes acpi_get_table_base(const char *name) {
-      int i;
-
-      for (i = 0; i < sdt_count; i++) {
-        // MODIFIED strncmp to placeholder
-        if (kstrncmp(name, sdt_trans[i].signature, ACPI_SDT_SIGNATURE_LEN) == 0)
-          return (phys_bytes)rsdt.data[i];
-      }
-
-      return (phys_bytes)0; // NULL might be undefined
-    }
-
-    k_size_t acpi_get_table_length(const char *name)     // MODIFIED size_t
-        k_size_t acpi_get_table_length(const char *name) // MODIFIED size_t
-    {
-      int i;
-
-      for (i = 0; i < sdt_count; i++) {
-        // MODIFIED strncmp to placeholder
-        if (kstrncmp(name, sdt_trans[i].signature, ACPI_SDT_SIGNATURE_LEN) == 0)
-          return sdt_trans[i].length;
-      }
-
-      return 0;
-    }
-
-    static void *acpi_madt_get_typed_item(struct acpi_madt_hdr * hdr,
-                                          unsigned char type, unsigned idx) {
-      u8_t *t, *end;
-      int i;
-
-      t = (u8_t *)hdr + sizeof(struct acpi_madt_hdr);
-      end = (u8_t *)hdr + hdr->hdr.length;
-
-      i = 0;
-      while (t < end) {
-        if (type == ((struct acpi_madt_item_hdr *)t)->type) {
-          if (i == idx)
-            return t;
-          else
-            i++;
-        }
-        t += ((struct acpi_madt_item_hdr *)t)->length;
-      }
-
-      return 0; // NULL might be undefined
-    }
-
-#if 0
-static void * acpi_madt_get_item(struct acpi_madt_hdr * hdr,
-				unsigned idx)
-{
-	u8_t * t, * end;
-	int i;
-
-	t = (u8_t *) hdr + sizeof(struct acpi_madt_hdr);
-	end = (u8_t *) hdr + hdr->hdr.length;
-
-	for(i = 0 ; i <= idx && t < end; i++) {
-		if (i == idx)
-			return t;
-		t += ((struct acpi_madt_item_hdr *) t)->length;
-	}
-
-	return 0; // NULL might be undefined
-}
-#endif
-
-    static int acpi_rsdp_test(void *buff) {
-      struct acpi_rsdp *rsdp = (struct acpi_rsdp *)buff;
-
-      if (!platform_tbl_checksum_ok(buff, 20))
-        return 0;
-      // MODIFIED strncmp to placeholder
-      if (kstrncmp(rsdp->signature, "RSD PTR ", 8))
-        return 0;
-
-      return 1;
-    }
-
-    static int get_acpi_rsdp(void) {
-      u16_t ebda;
-      /*
-       * Read 40:0Eh - to find the starting address of the EBDA.
-       */
-      acpi_phys_copy(0x40E, &ebda, sizeof(ebda));
-      if (ebda) {
-        ebda <<= 4;
-        if (platform_tbl_ptr(ebda, ebda + 0x400, 16, &acpi_rsdp,
-                             sizeof(acpi_rsdp), &machine.acpi_rsdp,
-                             acpi_rsdp_test))
-          return 1;
-      }
-
-      /* try BIOS read only mem space */
-      if (platform_tbl_ptr(0xE0000, 0x100000, 16, &acpi_rsdp, sizeof(acpi_rsdp),
-                           &machine.acpi_rsdp, acpi_rsdp_test))
-        return 1;
-
-      machine.acpi_rsdp = 0; /* RSDP cannot be found at this address therefore
-                                it is a valid negative value */
-      return 0;
-    }
-
-    static void acpi_init_poweroff(void) {
-      u8_t *ptr = 0;                            // NULL might be undefined
-      u8_t *start = 0;                          // NULL might be undefined
-      u8_t *end = 0;                            // NULL might be undefined
-      struct acpi_fadt_header *fadt_header = 0; // NULL might be undefined
-      struct acpi_rsdt *dsdt_header = 0;        // NULL might be undefined
-      char *msg = 0;                            // NULL might be undefined
-
-      /* Everything used here existed since ACPI spec 1.0 */
-      /* So we can safely use them */
-      fadt_header =
-          (struct acpi_fadt_header *)acpi_phys2vir(acpi_get_table_base("FACP"));
-      if (fadt_header == 0) { // NULL might be undefined
-        msg = "Could not load FACP";
-        goto exit;
-      }
-
-      dsdt_header =
-          (struct acpi_rsdt *)acpi_phys2vir((phys_bytes)fadt_header->dsdt);
-      if (dsdt_header == 0) { // NULL might be undefined
-        msg = "Could not load DSDT";
-        goto exit;
-      }
-
-      pm1a_cnt_blk = fadt_header->pm1a_cnt_blk;
-      pm1b_cnt_blk = fadt_header->pm1b_cnt_blk;
-
-      ptr = start = (u8_t *)dsdt_header->data;
-      end = start + dsdt_header->hdr.length - 4;
-
-      /* See http://forum.osdev.org/viewtopic.php?t=16990 */
-      /* for layout of \_S5 */
-      // MODIFIED memcmp to placeholder
-      while (ptr < end && (kmemcmp(ptr, "_S5_", 4) != 0))
-        ptr++;
-
-      msg = "Could not read S5 data. Use default SLP_TYPa and SLP_TYPb";
-      if (ptr >= end || ptr == start)
-        goto exit;
-
-      /* validate AML structure */
-      if (*(ptr + AMI_S5_PACKAGE_OP_OFFSET) != AMI_PACKAGE_OP_CODE)
-        goto exit;
-
-      if ((ptr < start + (-AMI_S5_NAME_OP_OFFSET_2) ||
-           (*(ptr + AMI_S5_NAME_OP_OFFSET_2) != AMI_NAME_OP_CODE ||
-            *(ptr + AMI_S5_NAME_OP_OFFSET_2 + 1) != '\\')) &&
-          *(ptr + AMI_S5_NAME_OP_OFFSET_1) != AMI_NAME_OP_CODE)
-        goto exit;
-
-      ptr += AMI_S5_PACKET_LENGTH_OFFSET;
-      if (ptr >= end)
-        goto exit;
-
-      /* package length */
-      ptr += ((*ptr & AMI_PACKAGE_LENGTH_ENCODING_BITS_MASK) >>
-              AMI_PACKAGE_LENGTH_ENCODING_BITS_SHIFT) +
-             AMI_MIN_PACKAGE_LENGTH + AMI_NUM_ELEMENTS_LENGTH;
-      if (ptr >= end)
-        goto exit;
-
-      if (*ptr == AMI_BYTE_PREFIX_CODE)
-        ptr++; /* skip byte prefix */
-
-      slp_typa = (*ptr) << AMI_SLP_TYPA_SHIFT;
-
-      ptr++; /* move to SLP_TYPb */
-      if (*ptr == AMI_BYTE_PREFIX_CODE)
-        ptr++; /* skip byte prefix */
-
-      slp_typb = (*ptr) << AMI_SLP_TYPB_SHIFT;
-
-      msg = "poweroff initialized";
-
-    exit:
-      if (msg) { // Check if msg is not 0
-        DEBUGBASIC(("acpi: %s\n", msg));
-      }
-    }
-
-    void acpi_init(void) {
-      int s, i;
-      read_func = acpi_phys_copy;
-
-      if (!get_acpi_rsdp()) {
-        kprintf_stub("WARNING : Cannot configure ACPI\n"); // MODIFIED
-        kprintf_stub("WARNING : Cannot configure ACPI\n"); // MODIFIED
-        return;
-      }
-
-      s = acpi_read_sdt_at(acpi_rsdp.rsdt_addr, (struct acpi_sdt_header *)&rsdt,
-                           sizeof(struct acpi_rsdt), ACPI_SDT_SIGNATURE(RSDT));
-
-      sdt_count = (s - sizeof(struct acpi_sdt_header)) / sizeof(u32_t);
-
-      for (i = 0; i < sdt_count; i++) {
-        struct acpi_sdt_header hdr;
-        int j;
-        if (read_func(rsdt.data[i], &hdr, sizeof(struct acpi_sdt_header))) {
-                        kprintf_stub("ERROR acpi cannot read header at 0x%x\n", // MODIFIED
-			kprintf_stub("ERROR acpi cannot read header at 0x%x\n", // MODIFIED
-								rsdt.data[i]);
-			return;
-        }
-
-        for (j = 0; j < ACPI_SDT_SIGNATURE_LEN; j++)
-          sdt_trans[i].signature[j] = hdr.signature[j];
-        sdt_trans[i].signature[ACPI_SDT_SIGNATURE_LEN] = '\0';
-        sdt_trans[i].length = hdr.length;
-      }
-
-      acpi_init_poweroff();
-    }
-
-    struct acpi_madt_ioapic *acpi_get_ioapic_next(void) {
-      static unsigned idx = 0;
-      static struct acpi_madt_hdr *madt_hdr;
-
-      struct acpi_madt_ioapic *ret;
-
-      if (idx == 0) {
-        madt_hdr =
-            (struct acpi_madt_hdr *)acpi_phys2vir(acpi_get_table_base("APIC"));
-        if (madt_hdr == 0) // NULL might be undefined
-          return 0;        // NULL might be undefined
-      }
-
-      ret = (struct acpi_madt_ioapic *)acpi_madt_get_typed_item(
-          madt_hdr, ACPI_MADT_TYPE_IOAPIC, idx);
-      if (ret)
-        idx++;
-
-      return ret;
-    }
-
-    struct acpi_madt_lapic *acpi_get_lapic_next(void) {
-      static unsigned idx = 0;
-      static struct acpi_madt_hdr *madt_hdr;
-
-      struct acpi_madt_lapic *ret;
-
-      if (idx == 0) {
-        madt_hdr =
-            (struct acpi_madt_hdr *)acpi_phys2vir(acpi_get_table_base("APIC"));
-        if (madt_hdr == 0) // NULL might be undefined
-          return 0;        // NULL might be undefined
-      }
-
-      for (;;) {
-        ret = (struct acpi_madt_lapic *)acpi_madt_get_typed_item(
-            madt_hdr, ACPI_MADT_TYPE_LAPIC, idx);
-        if (!ret)
-          break;
-
-        idx++;
-
-        /* report only usable CPUs */
-        if (ret->flags & 1)
-          break;
-      }
-
-      return ret;
-    }
-
-    void __k_unpaged_acpi_poweroff(void) { /* NO OP poweroff symbol*/ }
-
-    void acpi_poweroff(void) {
-      if (pm1a_cnt_blk == 0) {
-        return;
-      }
-      outw(pm1a_cnt_blk, slp_typa | SLP_EN_CODE);
-      if (pm1b_cnt_blk != 0) {
-        outw(pm1b_cnt_blk, slp_typb | SLP_EN_CODE);
-      }
-    }
-
-    /**
-     * @section kernel_uts_i86pc_os_acpi_stubs_c
-     * @brief Original file: minix/kernel/uts/i86pc/os/acpi_stubs.c
-     */
-    /*
-     * CDDL HEADER START
-     *
-     * The contents of this file are subject to the terms of the
-     * Common Development and Distribution License (the "License").
-     * You may not use this file except in compliance with the License.
-     *
-     * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-     * or http://www.opensolaris.org/os/licensing.
-     * See the License for the specific language governing permissions
-     * and limitations under the License.
-     *
-     * When distributing Covered Code, include this CDDL HEADER in each
-     * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-     * If applicable, add the following below this CDDL HEADER, with the
-     * fields enclosed by brackets "[]" replaced with your own identifying
-     * information: Portions Copyright [yyyy] [name of copyright owner]
-     *
-     * CDDL HEADER END
-     */
-    /*
-     * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
-     * Use is subject to license terms.
-     */
-
-#include <sys/types.h>
-
-#include <sys/acpi/acpi.h>
-#include <sys/acpica.h>
-
-    /*
-     * This file contains ACPI functions that are needed by the kernel before
-     * the ACPI module is loaded.  Any functions or definitions need to be
-     * able to deal with the possibility that ACPI doesn't get loaded, or
-     * doesn't contain the required method.
-     */
-
-    int (*acpi_fp_setwake)();
-
-    /*
-     *
-     */
-    int acpi_ddi_setwake(dev_info_t * dip, int level) {
-      if (acpi_fp_setwake == NULL)
-        return (AE_ERROR);
-
-      return ((*acpi_fp_setwake)(dip, level));
-    }
-
-    /**
-     * @section drivers_power_acpi_dispatcher_dsargs_c
-     * @brief Original file: minix/drivers/power/acpi/dispatcher/dsargs.c
-     */
-    /******************************************************************************
-     *
-     * Module Name: dsargs - Support for execution of dynamic arguments for
-     *static objects (regions, fields, buffer fields, etc.)
-     *
-     *****************************************************************************/
-
-    /*
-     * Copyright (C) 2000 - 2014, Intel Corp.
-     * All rights reserved.
-     *
-     * Redistribution and use in source and binary forms, with or without
-     * modification, are permitted provided that the following conditions
-     * are met:
-     * 1. Redistributions of source code must retain the above copyright
-     *    notice, this list of conditions, and the following disclaimer,
-     *    without modification.
-     * 2. Redistributions in binary form must reproduce at minimum a disclaimer
-     *    substantially similar to the "NO WARRANTY" disclaimer below
-     *    ("Disclaimer") and any redistribution must be conditioned upon
-     *    including a substantially similar Disclaimer requirement for further
-     *    binary redistribution.
-     * 3. Neither the names of the above-listed copyright holders nor the names
-     *    of any contributors may be used to endorse or promote products derived
-     *    from this software without specific prior written permission.
-     *
-     * Alternatively, this software may be distributed under the terms of the
-     * GNU General Public License ("GPL") version 2 as published by the Free
-     * Software Foundation.
-     *
-     * NO WARRANTY
-     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-     * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-     * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR
-     * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-     * HOLDERS OR CONTRIBUTORS BE LIABLE FOR SPECIAL, EXEMPLARY, OR
-     * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-     * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-     * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-     * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-     * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-     * THE POSSIBILITY OF SUCH DAMAGES.
-     */
-
-#include "accommon.h"
-#include "acdispat.h"
-#include "acnamesp.h"
-#include "acparser.h"
-#include "acpi.h"
-#include "amlcode.h"
-
-#define _COMPONENT ACPI_DISPATCHER
-    ACPI_MODULE_NAME("dsargs")
-
-    /* Local prototypes */
-
-    static ACPI_STATUS AcpiDsExecuteArguments(
-        ACPI_NAMESPACE_NODE * Node, ACPI_NAMESPACE_NODE * ScopeNode,
-        UINT32 AmlLength, UINT8 * AmlStart);
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiDsExecuteArguments
-     *
-     * PARAMETERS:  Node                - Object NS node
-     *              ScopeNode           - Parent NS node
-     *              AmlLength           - Length of executable AML
-     *              AmlStart            - Pointer to the AML
-     *
-     * RETURN:      Status.
-     *
-     * DESCRIPTION: Late (deferred) execution of region or field arguments
-     *
-     ******************************************************************************/
-
-    static ACPI_STATUS AcpiDsExecuteArguments(
-        ACPI_NAMESPACE_NODE * Node, ACPI_NAMESPACE_NODE * ScopeNode,
-        UINT32 AmlLength, UINT8 * AmlStart) {
-      ACPI_STATUS Status;
-      ACPI_PARSE_OBJECT *Op;
-      ACPI_WALK_STATE *WalkState;
-
-      ACPI_FUNCTION_TRACE(DsExecuteArguments);
-
-      /* Allocate a new parser op to be the root of the parsed tree */
-
-      Op = AcpiPsAllocOp(AML_INT_EVAL_SUBTREE_OP);
-      if (!Op) {
-        return_ACPI_STATUS(AE_NO_MEMORY);
-      }
-
-      /* Save the Node for use in AcpiPsParseAml */
-
-      Op->Common.Node = ScopeNode;
-
-      /* Create and initialize a new parser state */
-
-      WalkState = AcpiDsCreateWalkState(0, NULL, NULL, NULL);
-      if (!WalkState) {
-        Status = AE_NO_MEMORY;
-        goto Cleanup;
-      }
-
-      Status = AcpiDsInitAmlWalk(WalkState, Op, NULL, AmlStart, AmlLength, NULL,
-                                 ACPI_IMODE_LOAD_PASS1);
-      if (ACPI_FAILURE(Status)) {
-        AcpiDsDeleteWalkState(WalkState);
-        goto Cleanup;
-      }
-
-      /* Mark this parse as a deferred opcode */
-
-      WalkState->ParseFlags = ACPI_PARSE_DEFERRED_OP;
-      WalkState->DeferredNode = Node;
-
-      /* Pass1: Parse the entire declaration */
-
-      Status = AcpiPsParseAml(WalkState);
-      if (ACPI_FAILURE(Status)) {
-        goto Cleanup;
-      }
-
-      /* Get and init the Op created above */
-
-      Op->Common.Node = Node;
-      AcpiPsDeleteParseTree(Op);
-
-      /* Evaluate the deferred arguments */
-
-      Op = AcpiPsAllocOp(AML_INT_EVAL_SUBTREE_OP);
-      if (!Op) {
-        return_ACPI_STATUS(AE_NO_MEMORY);
-      }
-
-      Op->Common.Node = ScopeNode;
-
-      /* Create and initialize a new parser state */
-
-      WalkState = AcpiDsCreateWalkState(0, NULL, NULL, NULL);
-      if (!WalkState) {
-        Status = AE_NO_MEMORY;
-        goto Cleanup;
-      }
-
-      /* Execute the opcode and arguments */
-
-      Status = AcpiDsInitAmlWalk(WalkState, Op, NULL, AmlStart, AmlLength, NULL,
-                                 ACPI_IMODE_EXECUTE);
-      if (ACPI_FAILURE(Status)) {
-        AcpiDsDeleteWalkState(WalkState);
-        goto Cleanup;
-      }
-
-      /* Mark this execution as a deferred opcode */
-
-      WalkState->DeferredNode = Node;
-      Status = AcpiPsParseAml(WalkState);
-
-    Cleanup:
-      AcpiPsDeleteParseTree(Op);
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiDsGetBufferFieldArguments
-     *
-     * PARAMETERS:  ObjDesc         - A valid BufferField object
-     *
-     * RETURN:      Status.
-     *
-     * DESCRIPTION: Get BufferField Buffer and Index. This implements the late
-     *              evaluation of these field attributes.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiDsGetBufferFieldArguments(ACPI_OPERAND_OBJECT * ObjDesc) {
-      ACPI_OPERAND_OBJECT *ExtraDesc;
-      ACPI_NAMESPACE_NODE *Node;
-      ACPI_STATUS Status;
-
-      ACPI_FUNCTION_TRACE_PTR(DsGetBufferFieldArguments, ObjDesc);
-
-      if (ObjDesc->Common.Flags & AOPOBJ_DATA_VALID) {
-        return_ACPI_STATUS(AE_OK);
-      }
-
-      /* Get the AML pointer (method object) and BufferField node */
-
-      ExtraDesc = AcpiNsGetSecondaryObject(ObjDesc);
-      Node = ObjDesc->BufferField.Node;
-
-      ACPI_DEBUG_EXEC(
-          AcpiUtDisplayInitPathname(ACPI_TYPE_BUFFER_FIELD, Node, NULL));
-
-      ACPI_DEBUG_PRINT((ACPI_DB_EXEC, "[%4.4s] BufferField Arg Init\n",
-                        AcpiUtGetNodeName(Node)));
-
-      /* Execute the AML code for the TermArg arguments */
-
-      Status =
-          AcpiDsExecuteArguments(Node, Node->Parent, ExtraDesc->Extra.AmlLength,
-                                 ExtraDesc->Extra.AmlStart);
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiDsGetBankFieldArguments
-     *
-     * PARAMETERS:  ObjDesc         - A valid BankField object
-     *
-     * RETURN:      Status.
-     *
-     * DESCRIPTION: Get BankField BankValue. This implements the late
-     *              evaluation of these field attributes.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiDsGetBankFieldArguments(ACPI_OPERAND_OBJECT * ObjDesc) {
-      ACPI_OPERAND_OBJECT *ExtraDesc;
-      ACPI_NAMESPACE_NODE *Node;
-      ACPI_STATUS Status;
-
-      ACPI_FUNCTION_TRACE_PTR(DsGetBankFieldArguments, ObjDesc);
-
-      if (ObjDesc->Common.Flags & AOPOBJ_DATA_VALID) {
-        return_ACPI_STATUS(AE_OK);
-      }
-
-      /* Get the AML pointer (method object) and BankField node */
-
-      ExtraDesc = AcpiNsGetSecondaryObject(ObjDesc);
-      Node = ObjDesc->BankField.Node;
-
-      ACPI_DEBUG_EXEC(
-          AcpiUtDisplayInitPathname(ACPI_TYPE_LOCAL_BANK_FIELD, Node, NULL));
-
-      ACPI_DEBUG_PRINT((ACPI_DB_EXEC, "[%4.4s] BankField Arg Init\n",
-                        AcpiUtGetNodeName(Node)));
-
-      /* Execute the AML code for the TermArg arguments */
-
-      Status =
-          AcpiDsExecuteArguments(Node, Node->Parent, ExtraDesc->Extra.AmlLength,
-                                 ExtraDesc->Extra.AmlStart);
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiDsGetBufferArguments
-     *
-     * PARAMETERS:  ObjDesc         - A valid Buffer object
-     *
-     * RETURN:      Status.
-     *
-     * DESCRIPTION: Get Buffer length and initializer byte list. This implements
-     *              the late evaluation of these attributes.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiDsGetBufferArguments(ACPI_OPERAND_OBJECT * ObjDesc) {
-      ACPI_NAMESPACE_NODE *Node;
-      ACPI_STATUS Status;
-
-      ACPI_FUNCTION_TRACE_PTR(DsGetBufferArguments, ObjDesc);
-
-      if (ObjDesc->Common.Flags & AOPOBJ_DATA_VALID) {
-        return_ACPI_STATUS(AE_OK);
-      }
-
-      /* Get the Buffer node */
-
-      Node = ObjDesc->Buffer.Node;
-      if (!Node) {
-        ACPI_ERROR((AE_INFO,
-                    "No pointer back to namespace node in buffer object %p",
-                    ObjDesc));
-        return_ACPI_STATUS(AE_AML_INTERNAL);
-      }
-
-      ACPI_DEBUG_PRINT((ACPI_DB_EXEC, "Buffer Arg Init\n"));
-
-      /* Execute the AML code for the TermArg arguments */
-
-      Status = AcpiDsExecuteArguments(Node, Node, ObjDesc->Buffer.AmlLength,
-                                      ObjDesc->Buffer.AmlStart);
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiDsGetPackageArguments
-     *
-     * PARAMETERS:  ObjDesc         - A valid Package object
-     *
-     * RETURN:      Status.
-     *
-     * DESCRIPTION: Get Package length and initializer byte list. This
-     *implements the late evaluation of these attributes.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiDsGetPackageArguments(ACPI_OPERAND_OBJECT * ObjDesc) {
-      ACPI_NAMESPACE_NODE *Node;
-      ACPI_STATUS Status;
-
-      ACPI_FUNCTION_TRACE_PTR(DsGetPackageArguments, ObjDesc);
-
-      if (ObjDesc->Common.Flags & AOPOBJ_DATA_VALID) {
-        return_ACPI_STATUS(AE_OK);
-      }
-
-      /* Get the Package node */
-
-      Node = ObjDesc->Package.Node;
-      if (!Node) {
-        ACPI_ERROR((AE_INFO, "No pointer back to namespace node in package %p",
-                    ObjDesc));
-        return_ACPI_STATUS(AE_AML_INTERNAL);
-      }
-
-      ACPI_DEBUG_PRINT((ACPI_DB_EXEC, "Package Arg Init\n"));
-
-      /* Execute the AML code for the TermArg arguments */
-
-      Status = AcpiDsExecuteArguments(Node, Node, ObjDesc->Package.AmlLength,
-                                      ObjDesc->Package.AmlStart);
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiDsGetRegionArguments
-     *
-     * PARAMETERS:  ObjDesc         - A valid region object
-     *
-     * RETURN:      Status.
-     *
-     * DESCRIPTION: Get region address and length. This implements the late
-     *              evaluation of these region attributes.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiDsGetRegionArguments(ACPI_OPERAND_OBJECT * ObjDesc) {
-      ACPI_NAMESPACE_NODE *Node;
-      ACPI_STATUS Status;
-      ACPI_OPERAND_OBJECT *ExtraDesc;
-
-      ACPI_FUNCTION_TRACE_PTR(DsGetRegionArguments, ObjDesc);
-
-      if (ObjDesc->Region.Flags & AOPOBJ_DATA_VALID) {
-        return_ACPI_STATUS(AE_OK);
-      }
-
-      ExtraDesc = AcpiNsGetSecondaryObject(ObjDesc);
-      if (!ExtraDesc) {
-        return_ACPI_STATUS(AE_NOT_EXIST);
-      }
-
-      /* Get the Region node */
-
-      Node = ObjDesc->Region.Node;
-
-      ACPI_DEBUG_EXEC(AcpiUtDisplayInitPathname(ACPI_TYPE_REGION, Node, NULL));
-
-      ACPI_DEBUG_PRINT((ACPI_DB_EXEC, "[%4.4s] OpRegion Arg Init at AML %p\n",
-                        AcpiUtGetNodeName(Node), ExtraDesc->Extra.AmlStart));
-
-      /* Execute the argument AML */
-
-      Status = AcpiDsExecuteArguments(Node, ExtraDesc->Extra.ScopeNode,
-                                      ExtraDesc->Extra.AmlLength,
-                                      ExtraDesc->Extra.AmlStart);
-      if (ACPI_FAILURE(Status)) {
-        return_ACPI_STATUS(Status);
-      }
-
-      Status = AcpiUtAddAddressRange(ObjDesc->Region.SpaceId,
-                                     ObjDesc->Region.Address,
-                                     ObjDesc->Region.Length, Node);
-      return_ACPI_STATUS(Status);
-    }
-
-    /**
-     * @section drivers_power_acpi_executer_exsystem_c
-     * @brief Original file: minix/drivers/power/acpi/executer/exsystem.c
-     */
-    /******************************************************************************
-     *
-     * Module Name: exsystem - Interface to OS services
-     *
-     *****************************************************************************/
-
-    /*
-     * Copyright (C) 2000 - 2014, Intel Corp.
-     * All rights reserved.
-     *
-     * Redistribution and use in source and binary forms, with or without
-     * modification, are permitted provided that the following conditions
-     * are met:
-     * 1. Redistributions of source code must retain the above copyright
-     *    notice, this list of conditions, and the following disclaimer,
-     *    without modification.
-     * 2. Redistributions in binary form must reproduce at minimum a disclaimer
-     *    substantially similar to the "NO WARRANTY" disclaimer below
-     *    ("Disclaimer") and any redistribution must be conditioned upon
-     *    including a substantially similar Disclaimer requirement for further
-     *    binary redistribution.
-     * 3. Neither the names of the above-listed copyright holders nor the names
-     *    of any contributors may be used to endorse or promote products derived
-     *    from this software without specific prior written permission.
-     *
-     * Alternatively, this software may be distributed under the terms of the
-     * GNU General Public License ("GPL") version 2 as published by the Free
-     * Software Foundation.
-     *
-     * NO WARRANTY
-     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-     * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-     * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR
-     * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-     * HOLDERS OR CONTRIBUTORS BE LIABLE FOR SPECIAL, EXEMPLARY, OR
-     * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-     * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-     * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-     * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-     * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-     * THE POSSIBILITY OF SUCH DAMAGES.
-     */
-
-#include "accommon.h"
-#include "acinterp.h"
-#include "acpi.h"
-
-#define _COMPONENT ACPI_EXECUTER
-    ACPI_MODULE_NAME("exsystem")
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiExSystemWaitSemaphore
-     *
-     * PARAMETERS:  Semaphore       - Semaphore to wait on
-     *              Timeout         - Max time to wait
-     *
-     * RETURN:      Status
-     *
-     * DESCRIPTION: Implements a semaphore wait with a check to see if the
-     *              semaphore is available immediately. If it is not, the
-     *              interpreter is released before waiting.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiExSystemWaitSemaphore(ACPI_SEMAPHORE Semaphore, UINT16 Timeout) {
-      ACPI_STATUS Status;
-
-      ACPI_FUNCTION_TRACE(ExSystemWaitSemaphore);
-
-      Status = AcpiOsWaitSemaphore(Semaphore, 1, ACPI_DO_NOT_WAIT);
-      if (ACPI_SUCCESS(Status)) {
-        return_ACPI_STATUS(Status);
-      }
-
-      if (Status == AE_TIME) {
-        /* We must wait, so unlock the interpreter */
-
-        AcpiExExitInterpreter();
-
-        Status = AcpiOsWaitSemaphore(Semaphore, 1, Timeout);
-
-        ACPI_DEBUG_PRINT((ACPI_DB_EXEC, "*** Thread awake after blocking, %s\n",
-                          AcpiFormatException(Status)));
-
-        /* Reacquire the interpreter */
-
-        AcpiExEnterInterpreter();
-      }
-
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiExSystemWaitMutex
-     *
-     * PARAMETERS:  Mutex           - Mutex to wait on
-     *              Timeout         - Max time to wait
-     *
-     * RETURN:      Status
-     *
-     * DESCRIPTION: Implements a mutex wait with a check to see if the
-     *              mutex is available immediately. If it is not, the
-     *              interpreter is released before waiting.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiExSystemWaitMutex(ACPI_MUTEX Mutex, UINT16 Timeout) {
-      ACPI_STATUS Status;
-
-      ACPI_FUNCTION_TRACE(ExSystemWaitMutex);
-
-      Status = AcpiOsAcquireMutex(Mutex, ACPI_DO_NOT_WAIT);
-      if (ACPI_SUCCESS(Status)) {
-        return_ACPI_STATUS(Status);
-      }
-
-      if (Status == AE_TIME) {
-        /* We must wait, so unlock the interpreter */
-
-        AcpiExExitInterpreter();
-
-        Status = AcpiOsAcquireMutex(Mutex, Timeout);
-
-        ACPI_DEBUG_PRINT((ACPI_DB_EXEC, "*** Thread awake after blocking, %s\n",
-                          AcpiFormatException(Status)));
-
-        /* Reacquire the interpreter */
-
-        AcpiExEnterInterpreter();
-      }
-
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiExSystemDoStall
-     *
-     * PARAMETERS:  HowLong         - The amount of time to stall,
-     *                                in microseconds
-     *
-     * RETURN:      Status
-     *
-     * DESCRIPTION: Suspend running thread for specified amount of time.
-     *              Note: ACPI specification requires that Stall() does not
-     *              relinquish the processor, and delays longer than 100 usec
-     *              should use Sleep() instead. We allow stalls up to 255 usec
-     *              for compatibility with other interpreters and existing
-     *BIOSs.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiExSystemDoStall(UINT32 HowLong) {
-      ACPI_STATUS Status = AE_OK;
-
-      ACPI_FUNCTION_ENTRY();
-
-      if (HowLong > 255) /* 255 microseconds */
-      {
-        /*
-         * Longer than 255 usec, this is an error
-         *
-         * (ACPI specifies 100 usec as max, but this gives some slack in
-         * order to support existing BIOSs)
-         */
-        ACPI_ERROR((AE_INFO, "Time parameter is too large (%u)", HowLong));
-        Status = AE_AML_OPERAND_VALUE;
-      } else {
-        AcpiOsStall(HowLong);
-      }
-
-      return (Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiExSystemDoSleep
-     *
-     * PARAMETERS:  HowLong         - The amount of time to sleep,
-     *                                in milliseconds
-     *
-     * RETURN:      None
-     *
-     * DESCRIPTION: Sleep the running thread for specified amount of time.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiExSystemDoSleep(UINT64 HowLong) {
-      ACPI_FUNCTION_ENTRY();
-
-      /* Since this thread will sleep, we must release the interpreter */
-
-      AcpiExExitInterpreter();
-
-      /*
-       * For compatibility with other ACPI implementations and to prevent
-       * accidental deep sleeps, limit the sleep time to something reasonable.
-       */
-      if (HowLong > ACPI_MAX_SLEEP) {
-        HowLong = ACPI_MAX_SLEEP;
-      }
-
-      AcpiOsSleep(HowLong);
-
-      /* And now we must get the interpreter again */
-
-      AcpiExEnterInterpreter();
-      return (AE_OK);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiExSystemSignalEvent
-     *
-     * PARAMETERS:  ObjDesc         - The object descriptor for this op
-     *
-     * RETURN:      Status
-     *
-     * DESCRIPTION: Provides an access point to perform synchronization
-     *operations within the AML.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiExSystemSignalEvent(ACPI_OPERAND_OBJECT * ObjDesc) {
-      ACPI_STATUS Status = AE_OK;
-
-      ACPI_FUNCTION_TRACE(ExSystemSignalEvent);
-
-      if (ObjDesc) {
-        Status = AcpiOsSignalSemaphore(ObjDesc->Event.OsSemaphore, 1);
-      }
-
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiExSystemWaitEvent
-     *
-     * PARAMETERS:  TimeDesc        - The 'time to delay' object descriptor
-     *              ObjDesc         - The object descriptor for this op
-     *
-     * RETURN:      Status
-     *
-     * DESCRIPTION: Provides an access point to perform synchronization
-     *operations within the AML. This operation is a request to wait for an
-     *              event.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiExSystemWaitEvent(ACPI_OPERAND_OBJECT * TimeDesc,
-                          ACPI_OPERAND_OBJECT * ObjDesc) {
-      ACPI_STATUS Status = AE_OK;
-
-      ACPI_FUNCTION_TRACE(ExSystemWaitEvent);
-
-      if (ObjDesc) {
-        Status = AcpiExSystemWaitSemaphore(ObjDesc->Event.OsSemaphore,
-                                           (UINT16)TimeDesc->Integer.Value);
-      }
-
-      return_ACPI_STATUS(Status);
-    }
-
-    /*******************************************************************************
-     *
-     * FUNCTION:    AcpiExSystemResetEvent
-     *
-     * PARAMETERS:  ObjDesc         - The object descriptor for this op
-     *
-     * RETURN:      Status
-     *
-     * DESCRIPTION: Reset an event to a known state.
-     *
-     ******************************************************************************/
-
-    ACPI_STATUS
-    AcpiExSystemResetEvent(ACPI_OPERAND_OBJECT * ObjDesc) {
-      ACPI_STATUS Status = AE_OK;
-      ACPI_SEMAPHORE TempSemaphore;
-
-      ACPI_FUNCTION_ENTRY();
-
-      /*
-       * We are going to simply delete the existing semaphore and
-       * create a new one!
-       */
-      Status = AcpiOsCreateSemaphore(ACPI_NO_UNIT_LIMIT, 0, &TempSemaphore);
-      if (ACPI_SUCCESS(Status)) {
-        (void)AcpiOsDeleteSemaphore(ObjDesc->Event.OsSemaphore);
-        ObjDesc->Event.OsSemaphore = TempSemaphore;
-      }
-
-      return (Status);
-    }
+#include "arch/i386/acpi.c"
+
+/**
+ * @section minix_kernel_boot_efi_loader_acpi_c
+ * @brief Original file: minix/kernel/boot/efi/loader/acpi.c
+ */
+#include "boot/efi/loader/acpi.c"
+
+/**
+ * @section minix_kernel_boot_i386_libi386_biosacpi_c
+ * @brief Original file: minix/kernel/boot/i386/libi386/biosacpi.c
+ */
+#include "boot/i386/libi386/biosacpi.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpidump_apdump_c
+ * @brief Original file: minix/kernel/cmd/acpi/acpidump/apdump.c
+ */
+#include "cmd/acpi/acpidump/apdump.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpidump_apfiles_c
+ * @brief Original file: minix/kernel/cmd/acpi/acpidump/apfiles.c
+ */
+#include "cmd/acpi/acpidump/apfiles.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpidump_apmain_c
+ * @brief Original file: minix/kernel/cmd/acpi/acpidump/apmain.c
+ */
+#include "cmd/acpi/acpidump/apmain.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpidump_osillumostbl_c
+ * @brief Original file: minix/kernel/cmd/acpi/acpidump/osillumostbl.c
+ */
+#include "cmd/acpi/acpidump/osillumostbl.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpidump_osunixdir_c
+ * @brief Original file: minix/kernel/cmd/acpi/acpidump/osunixdir.c
+ */
+#include "cmd/acpi/acpidump/osunixdir.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpixtract_acpixtract_c
+ * @brief Original file: minix/kernel/cmd/acpi/acpixtract/acpixtract.c
+ */
+#include "cmd/acpi/acpixtract/acpixtract.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpixtract_axmain_c
+ * @brief Original file: minix/kernel/cmd/acpi/acpixtract/axmain.c
+ */
+#include "cmd/acpi/acpixtract/axmain.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpixtract_axutils_c
+ * @brief Original file: minix/kernel/cmd/acpi/acpixtract/axutils.c
+ */
+#include "cmd/acpi/acpixtract/axutils.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_acfileio_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/acfileio.c
+ */
+#include "cmd/acpi/common/acfileio.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_acgetline_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/acgetline.c
+ */
+#include "cmd/acpi/common/acgetline.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_adfile_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/adfile.c
+ */
+#include "cmd/acpi/common/adfile.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_adisasm_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/adisasm.c
+ */
+#include "cmd/acpi/common/adisasm.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_adwalk_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/adwalk.c
+ */
+#include "cmd/acpi/common/adwalk.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_ahids_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/ahids.c
+ */
+#include "cmd/acpi/common/ahids.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_ahpredef_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/ahpredef.c
+ */
+#include "cmd/acpi/common/ahpredef.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_ahtable_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/ahtable.c
+ */
+#include "cmd/acpi/common/ahtable.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_ahuuids_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/ahuuids.c
+ */
+#include "cmd/acpi/common/ahuuids.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_cmfsize_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/cmfsize.c
+ */
+#include "cmd/acpi/common/cmfsize.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmextern_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmextern.c
+ */
+#include "cmd/acpi/common/dmextern.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmrestag_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmrestag.c
+ */
+#include "cmd/acpi/common/dmrestag.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmswitch_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmswitch.c
+ */
+#include "cmd/acpi/common/dmswitch.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtable_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtable.c
+ */
+#include "cmd/acpi/common/dmtable.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtables_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtables.c
+ */
+#include "cmd/acpi/common/dmtables.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtbdump_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtbdump.c
+ */
+#include "cmd/acpi/common/dmtbdump.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtbdump1_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtbdump1.c
+ */
+#include "cmd/acpi/common/dmtbdump1.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtbdump2_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtbdump2.c
+ */
+#include "cmd/acpi/common/dmtbdump2.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtbdump3_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtbdump3.c
+ */
+#include "cmd/acpi/common/dmtbdump3.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtbinfo_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtbinfo.c
+ */
+#include "cmd/acpi/common/dmtbinfo.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtbinfo1_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtbinfo1.c
+ */
+#include "cmd/acpi/common/dmtbinfo1.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtbinfo2_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtbinfo2.c
+ */
+#include "cmd/acpi/common/dmtbinfo2.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_dmtbinfo3_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/dmtbinfo3.c
+ */
+#include "cmd/acpi/common/dmtbinfo3.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_getopt_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/getopt.c
+ */
+#include "cmd/acpi/common/getopt.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_osl_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/osl.c
+ */
+#include "cmd/acpi/common/osl.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_common_osunixxf_c
+ * @brief Original file: minix/kernel/cmd/acpi/common/osunixxf.c
+ */
+#include "cmd/acpi/common/osunixxf.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslallocate_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslallocate.c
+ */
+#include "cmd/acpi/iasl/aslallocate.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslanalyze_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslanalyze.c
+ */
+#include "cmd/acpi/iasl/aslanalyze.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslascii_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslascii.c
+ */
+#include "cmd/acpi/iasl/aslascii.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslbtypes_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslbtypes.c
+ */
+#include "cmd/acpi/iasl/aslbtypes.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslcache_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslcache.c
+ */
+#include "cmd/acpi/iasl/aslcache.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslcodegen_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslcodegen.c
+ */
+#include "cmd/acpi/iasl/aslcodegen.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslcompile_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslcompile.c
+ */
+#include "cmd/acpi/iasl/aslcompile.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asldebug_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asldebug.c
+ */
+#include "cmd/acpi/iasl/asldebug.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslerror_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslerror.c
+ */
+#include "cmd/acpi/iasl/aslerror.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslexternal_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslexternal.c
+ */
+#include "cmd/acpi/iasl/aslexternal.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslfileio_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslfileio.c
+ */
+#include "cmd/acpi/iasl/aslfileio.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslfiles_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslfiles.c
+ */
+#include "cmd/acpi/iasl/aslfiles.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslfold_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslfold.c
+ */
+#include "cmd/acpi/iasl/aslfold.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslhelp_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslhelp.c
+ */
+#include "cmd/acpi/iasl/aslhelp.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslhex_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslhex.c
+ */
+#include "cmd/acpi/iasl/aslhex.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asllength_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asllength.c
+ */
+#include "cmd/acpi/iasl/asllength.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asllisting_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asllisting.c
+ */
+#include "cmd/acpi/iasl/asllisting.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asllistsup_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asllistsup.c
+ */
+#include "cmd/acpi/iasl/asllistsup.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslload_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslload.c
+ */
+#include "cmd/acpi/iasl/aslload.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asllookup_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asllookup.c
+ */
+#include "cmd/acpi/iasl/asllookup.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslmain_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslmain.c
+ */
+#include "cmd/acpi/iasl/aslmain.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslmap_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslmap.c
+ */
+#include "cmd/acpi/iasl/aslmap.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslmapenter_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslmapenter.c
+ */
+#include "cmd/acpi/iasl/aslmapenter.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslmapoutput_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslmapoutput.c
+ */
+#include "cmd/acpi/iasl/aslmapoutput.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslmaputils_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslmaputils.c
+ */
+#include "cmd/acpi/iasl/aslmaputils.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslmessages_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslmessages.c
+ */
+#include "cmd/acpi/iasl/aslmessages.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslmethod_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslmethod.c
+ */
+#include "cmd/acpi/iasl/aslmethod.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslnamesp_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslnamesp.c
+ */
+#include "cmd/acpi/iasl/aslnamesp.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asloffset_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asloffset.c
+ */
+#include "cmd/acpi/iasl/asloffset.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslopcodes_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslopcodes.c
+ */
+#include "cmd/acpi/iasl/aslopcodes.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asloperands_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asloperands.c
+ */
+#include "cmd/acpi/iasl/asloperands.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslopt_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslopt.c
+ */
+#include "cmd/acpi/iasl/aslopt.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asloptions_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asloptions.c
+ */
+#include "cmd/acpi/iasl/asloptions.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslparseop_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslparseop.c
+ */
+#include "cmd/acpi/iasl/aslparseop.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslpld_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslpld.c
+ */
+#include "cmd/acpi/iasl/aslpld.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslpredef_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslpredef.c
+ */
+#include "cmd/acpi/iasl/aslpredef.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslprepkg_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslprepkg.c
+ */
+#include "cmd/acpi/iasl/aslprepkg.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslprintf_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslprintf.c
+ */
+#include "cmd/acpi/iasl/aslprintf.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslprune_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslprune.c
+ */
+#include "cmd/acpi/iasl/aslprune.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslresource_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslresource.c
+ */
+#include "cmd/acpi/iasl/aslresource.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslrestype1_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslrestype1.c
+ */
+#include "cmd/acpi/iasl/aslrestype1.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslrestype1i_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslrestype1i.c
+ */
+#include "cmd/acpi/iasl/aslrestype1i.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslrestype2_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslrestype2.c
+ */
+#include "cmd/acpi/iasl/aslrestype2.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslrestype2d_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslrestype2d.c
+ */
+#include "cmd/acpi/iasl/aslrestype2d.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslrestype2e_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslrestype2e.c
+ */
+#include "cmd/acpi/iasl/aslrestype2e.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslrestype2q_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslrestype2q.c
+ */
+#include "cmd/acpi/iasl/aslrestype2q.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslrestype2s_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslrestype2s.c
+ */
+#include "cmd/acpi/iasl/aslrestype2s.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslrestype2w_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslrestype2w.c
+ */
+#include "cmd/acpi/iasl/aslrestype2w.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslstartup_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslstartup.c
+ */
+#include "cmd/acpi/iasl/aslstartup.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslstubs_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslstubs.c
+ */
+#include "cmd/acpi/iasl/aslstubs.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asltransform_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asltransform.c
+ */
+#include "cmd/acpi/iasl/asltransform.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asltree_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asltree.c
+ */
+#include "cmd/acpi/iasl/asltree.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslutils_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslutils.c
+ */
+#include "cmd/acpi/iasl/aslutils.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asluuid_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asluuid.c
+ */
+#include "cmd/acpi/iasl/asluuid.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslwalks_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslwalks.c
+ */
+#include "cmd/acpi/iasl/aslwalks.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslxref_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslxref.c
+ */
+#include "cmd/acpi/iasl/aslxref.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslxrefout_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslxrefout.c
+ */
+#include "cmd/acpi/iasl/aslxrefout.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_cvcompiler_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/cvcompiler.c
+ */
+#include "cmd/acpi/iasl/cvcompiler.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_cvdisasm_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/cvdisasm.c
+ */
+#include "cmd/acpi/iasl/cvdisasm.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_cvparser_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/cvparser.c
+ */
+#include "cmd/acpi/iasl/cvparser.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dtcompile_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dtcompile.c
+ */
+#include "cmd/acpi/iasl/dtcompile.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dtexpress_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dtexpress.c
+ */
+#include "cmd/acpi/iasl/dtexpress.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dtfield_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dtfield.c
+ */
+#include "cmd/acpi/iasl/dtfield.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dtio_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dtio.c
+ */
+#include "cmd/acpi/iasl/dtio.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dtsubtable_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dtsubtable.c
+ */
+#include "cmd/acpi/iasl/dtsubtable.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dttable_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dttable.c
+ */
+#include "cmd/acpi/iasl/dttable.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dttable1_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dttable1.c
+ */
+#include "cmd/acpi/iasl/dttable1.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dttable2_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dttable2.c
+ */
+#include "cmd/acpi/iasl/dttable2.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dttemplate_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dttemplate.c
+ */
+#include "cmd/acpi/iasl/dttemplate.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dtutils_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dtutils.c
+ */
+#include "cmd/acpi/iasl/dtutils.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_prexpress_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/prexpress.c
+ */
+#include "cmd/acpi/iasl/prexpress.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_prmacros_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/prmacros.c
+ */
+#include "cmd/acpi/iasl/prmacros.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_prscan_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/prscan.c
+ */
+#include "cmd/acpi/iasl/prscan.c"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_prutils_c
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/prutils.c
+ */
+#include "cmd/acpi/iasl/prutils.c"
+
+/**
+ * @section minix_kernel_cmd_acpihpd_acpihpd_c
+ * @brief Original file: minix/kernel/cmd/acpihpd/acpihpd.c
+ */
+#include "cmd/acpihpd/acpihpd.c"
+
+/**
+ * @section minix_kernel_cmd_acpihpd_notify_c
+ * @brief Original file: minix/kernel/cmd/acpihpd/notify.c
+ */
+#include "cmd/acpihpd/notify.c"
+
+/**
+ * @section minix_kernel_cmd_bhyve_common_acpi_c
+ * @brief Original file: minix/kernel/cmd/bhyve/common/acpi.c
+ */
+#include "cmd/bhyve/common/acpi.c"
+
+/**
+ * @section minix_kernel_cmd_bhyve_common_acpi_device_c
+ * @brief Original file: minix/kernel/cmd/bhyve/common/acpi_device.c
+ */
+#include "cmd/bhyve/common/acpi_device.c"
+
+/**
+ * @section minix_kernel_cmd_hal_addons_acpi_addon-acpi_c
+ * @brief Original file: minix/kernel/cmd/hal/addons/acpi/addon-acpi.c
+ */
+#include "cmd/hal/addons/acpi/addon-acpi.c"
+
+/**
+ * @section minix_kernel_cmd_hal_hald_solaris_devinfo_acpi_c
+ * @brief Original file: minix/kernel/cmd/hal/hald/solaris/devinfo_acpi.c
+ */
+#include "cmd/hal/hald/solaris/devinfo_acpi.c"
+
+/**
+ * @section minix_kernel_cmd_hal_probing_acpi_probe-acpi_c
+ * @brief Original file: minix/kernel/cmd/hal/probing/acpi/probe-acpi.c
+ */
+#include "cmd/hal/probing/acpi/probe-acpi.c"
+
+/**
+ * @section minix_kernel_cmd_hal_utils_acpi_c
+ * @brief Original file: minix/kernel/cmd/hal/utils/acpi.c
+ */
+#include "cmd/hal/utils/acpi.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmbuffer_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmbuffer.c
+ */
+#include "common/acpica/disassembler/dmbuffer.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmcstyle_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmcstyle.c
+ */
+#include "common/acpica/disassembler/dmcstyle.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmdeferred_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmdeferred.c
+ */
+#include "common/acpica/disassembler/dmdeferred.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmnames_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmnames.c
+ */
+#include "common/acpica/disassembler/dmnames.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmopcode_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmopcode.c
+ */
+#include "common/acpica/disassembler/dmopcode.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmresrc_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmresrc.c
+ */
+#include "common/acpica/disassembler/dmresrc.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmresrcl_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmresrcl.c
+ */
+#include "common/acpica/disassembler/dmresrcl.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmresrcl2_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmresrcl2.c
+ */
+#include "common/acpica/disassembler/dmresrcl2.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmresrcs_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmresrcs.c
+ */
+#include "common/acpica/disassembler/dmresrcs.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmutils_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmutils.c
+ */
+#include "common/acpica/disassembler/dmutils.c"
+
+/**
+ * @section minix_kernel_common_acpica_disassembler_dmwalk_c
+ * @brief Original file: minix/kernel/common/acpica/disassembler/dmwalk.c
+ */
+#include "common/acpica/disassembler/dmwalk.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsargs_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsargs.c
+ */
+#include "common/acpica/dispatcher/dsargs.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dscontrol_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dscontrol.c
+ */
+#include "common/acpica/dispatcher/dscontrol.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsdebug_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsdebug.c
+ */
+#include "common/acpica/dispatcher/dsdebug.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsfield_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsfield.c
+ */
+#include "common/acpica/dispatcher/dsfield.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsinit_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsinit.c
+ */
+#include "common/acpica/dispatcher/dsinit.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsmethod_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsmethod.c
+ */
+#include "common/acpica/dispatcher/dsmethod.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsmthdat_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsmthdat.c
+ */
+#include "common/acpica/dispatcher/dsmthdat.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsobject_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsobject.c
+ */
+#include "common/acpica/dispatcher/dsobject.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsopcode_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsopcode.c
+ */
+#include "common/acpica/dispatcher/dsopcode.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dspkginit_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dspkginit.c
+ */
+#include "common/acpica/dispatcher/dspkginit.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dsutils_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dsutils.c
+ */
+#include "common/acpica/dispatcher/dsutils.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dswexec_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dswexec.c
+ */
+#include "common/acpica/dispatcher/dswexec.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dswload_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dswload.c
+ */
+#include "common/acpica/dispatcher/dswload.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dswload2_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dswload2.c
+ */
+#include "common/acpica/dispatcher/dswload2.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dswscope_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dswscope.c
+ */
+#include "common/acpica/dispatcher/dswscope.c"
+
+/**
+ * @section minix_kernel_common_acpica_dispatcher_dswstate_c
+ * @brief Original file: minix/kernel/common/acpica/dispatcher/dswstate.c
+ */
+#include "common/acpica/dispatcher/dswstate.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evevent_c
+ * @brief Original file: minix/kernel/common/acpica/events/evevent.c
+ */
+#include "common/acpica/events/evevent.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evglock_c
+ * @brief Original file: minix/kernel/common/acpica/events/evglock.c
+ */
+#include "common/acpica/events/evglock.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evgpe_c
+ * @brief Original file: minix/kernel/common/acpica/events/evgpe.c
+ */
+#include "common/acpica/events/evgpe.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evgpeblk_c
+ * @brief Original file: minix/kernel/common/acpica/events/evgpeblk.c
+ */
+#include "common/acpica/events/evgpeblk.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evgpeinit_c
+ * @brief Original file: minix/kernel/common/acpica/events/evgpeinit.c
+ */
+#include "common/acpica/events/evgpeinit.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evgpeutil_c
+ * @brief Original file: minix/kernel/common/acpica/events/evgpeutil.c
+ */
+#include "common/acpica/events/evgpeutil.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evhandler_c
+ * @brief Original file: minix/kernel/common/acpica/events/evhandler.c
+ */
+#include "common/acpica/events/evhandler.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evmisc_c
+ * @brief Original file: minix/kernel/common/acpica/events/evmisc.c
+ */
+#include "common/acpica/events/evmisc.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evregion_c
+ * @brief Original file: minix/kernel/common/acpica/events/evregion.c
+ */
+#include "common/acpica/events/evregion.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evrgnini_c
+ * @brief Original file: minix/kernel/common/acpica/events/evrgnini.c
+ */
+#include "common/acpica/events/evrgnini.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evsci_c
+ * @brief Original file: minix/kernel/common/acpica/events/evsci.c
+ */
+#include "common/acpica/events/evsci.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evxface_c
+ * @brief Original file: minix/kernel/common/acpica/events/evxface.c
+ */
+#include "common/acpica/events/evxface.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evxfevnt_c
+ * @brief Original file: minix/kernel/common/acpica/events/evxfevnt.c
+ */
+#include "common/acpica/events/evxfevnt.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evxfgpe_c
+ * @brief Original file: minix/kernel/common/acpica/events/evxfgpe.c
+ */
+#include "common/acpica/events/evxfgpe.c"
+
+/**
+ * @section minix_kernel_common_acpica_events_evxfregn_c
+ * @brief Original file: minix/kernel/common/acpica/events/evxfregn.c
+ */
+#include "common/acpica/events/evxfregn.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exconcat_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exconcat.c
+ */
+#include "common/acpica/executer/exconcat.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exconfig_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exconfig.c
+ */
+#include "common/acpica/executer/exconfig.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exconvrt_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exconvrt.c
+ */
+#include "common/acpica/executer/exconvrt.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_excreate_c
+ * @brief Original file: minix/kernel/common/acpica/executer/excreate.c
+ */
+#include "common/acpica/executer/excreate.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exdebug_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exdebug.c
+ */
+#include "common/acpica/executer/exdebug.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exdump_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exdump.c
+ */
+#include "common/acpica/executer/exdump.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exfield_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exfield.c
+ */
+#include "common/acpica/executer/exfield.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exfldio_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exfldio.c
+ */
+#include "common/acpica/executer/exfldio.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exmisc_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exmisc.c
+ */
+#include "common/acpica/executer/exmisc.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exmutex_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exmutex.c
+ */
+#include "common/acpica/executer/exmutex.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exnames_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exnames.c
+ */
+#include "common/acpica/executer/exnames.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exoparg1_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exoparg1.c
+ */
+#include "common/acpica/executer/exoparg1.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exoparg2_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exoparg2.c
+ */
+#include "common/acpica/executer/exoparg2.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exoparg3_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exoparg3.c
+ */
+#include "common/acpica/executer/exoparg3.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exoparg6_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exoparg6.c
+ */
+#include "common/acpica/executer/exoparg6.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exprep_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exprep.c
+ */
+#include "common/acpica/executer/exprep.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exregion_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exregion.c
+ */
+#include "common/acpica/executer/exregion.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exresnte_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exresnte.c
+ */
+#include "common/acpica/executer/exresnte.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exresolv_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exresolv.c
+ */
+#include "common/acpica/executer/exresolv.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exresop_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exresop.c
+ */
+#include "common/acpica/executer/exresop.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exstore_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exstore.c
+ */
+#include "common/acpica/executer/exstore.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exstoren_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exstoren.c
+ */
+#include "common/acpica/executer/exstoren.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exstorob_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exstorob.c
+ */
+#include "common/acpica/executer/exstorob.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exsystem_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exsystem.c
+ */
+#include "common/acpica/executer/exsystem.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_extrace_c
+ * @brief Original file: minix/kernel/common/acpica/executer/extrace.c
+ */
+#include "common/acpica/executer/extrace.c"
+
+/**
+ * @section minix_kernel_common_acpica_executer_exutils_c
+ * @brief Original file: minix/kernel/common/acpica/executer/exutils.c
+ */
+#include "common/acpica/executer/exutils.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwacpi_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwacpi.c
+ */
+#include "common/acpica/hardware/hwacpi.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwesleep_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwesleep.c
+ */
+#include "common/acpica/hardware/hwesleep.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwgpe_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwgpe.c
+ */
+#include "common/acpica/hardware/hwgpe.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwpci_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwpci.c
+ */
+#include "common/acpica/hardware/hwpci.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwregs_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwregs.c
+ */
+#include "common/acpica/hardware/hwregs.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwsleep_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwsleep.c
+ */
+#include "common/acpica/hardware/hwsleep.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwtimer_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwtimer.c
+ */
+#include "common/acpica/hardware/hwtimer.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwvalid_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwvalid.c
+ */
+#include "common/acpica/hardware/hwvalid.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwxface_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwxface.c
+ */
+#include "common/acpica/hardware/hwxface.c"
+
+/**
+ * @section minix_kernel_common_acpica_hardware_hwxfsleep_c
+ * @brief Original file: minix/kernel/common/acpica/hardware/hwxfsleep.c
+ */
+#include "common/acpica/hardware/hwxfsleep.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsaccess_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsaccess.c
+ */
+#include "common/acpica/namespace/nsaccess.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsalloc_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsalloc.c
+ */
+#include "common/acpica/namespace/nsalloc.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsarguments_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsarguments.c
+ */
+#include "common/acpica/namespace/nsarguments.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsconvert_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsconvert.c
+ */
+#include "common/acpica/namespace/nsconvert.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsdump_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsdump.c
+ */
+#include "common/acpica/namespace/nsdump.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsdumpdv_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsdumpdv.c
+ */
+#include "common/acpica/namespace/nsdumpdv.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nseval_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nseval.c
+ */
+#include "common/acpica/namespace/nseval.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsinit_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsinit.c
+ */
+#include "common/acpica/namespace/nsinit.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsload_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsload.c
+ */
+#include "common/acpica/namespace/nsload.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsnames_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsnames.c
+ */
+#include "common/acpica/namespace/nsnames.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsobject_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsobject.c
+ */
+#include "common/acpica/namespace/nsobject.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsparse_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsparse.c
+ */
+#include "common/acpica/namespace/nsparse.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nspredef_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nspredef.c
+ */
+#include "common/acpica/namespace/nspredef.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsprepkg_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsprepkg.c
+ */
+#include "common/acpica/namespace/nsprepkg.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsrepair_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsrepair.c
+ */
+#include "common/acpica/namespace/nsrepair.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsrepair2_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsrepair2.c
+ */
+#include "common/acpica/namespace/nsrepair2.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nssearch_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nssearch.c
+ */
+#include "common/acpica/namespace/nssearch.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsutils_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsutils.c
+ */
+#include "common/acpica/namespace/nsutils.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nswalk_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nswalk.c
+ */
+#include "common/acpica/namespace/nswalk.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsxfeval_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsxfeval.c
+ */
+#include "common/acpica/namespace/nsxfeval.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsxfname_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsxfname.c
+ */
+#include "common/acpica/namespace/nsxfname.c"
+
+/**
+ * @section minix_kernel_common_acpica_namespace_nsxfobj_c
+ * @brief Original file: minix/kernel/common/acpica/namespace/nsxfobj.c
+ */
+#include "common/acpica/namespace/nsxfobj.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psargs_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psargs.c
+ */
+#include "common/acpica/parser/psargs.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psloop_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psloop.c
+ */
+#include "common/acpica/parser/psloop.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psobject_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psobject.c
+ */
+#include "common/acpica/parser/psobject.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psopcode_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psopcode.c
+ */
+#include "common/acpica/parser/psopcode.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psopinfo_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psopinfo.c
+ */
+#include "common/acpica/parser/psopinfo.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psparse_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psparse.c
+ */
+#include "common/acpica/parser/psparse.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psscope_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psscope.c
+ */
+#include "common/acpica/parser/psscope.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_pstree_c
+ * @brief Original file: minix/kernel/common/acpica/parser/pstree.c
+ */
+#include "common/acpica/parser/pstree.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psutils_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psutils.c
+ */
+#include "common/acpica/parser/psutils.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_pswalk_c
+ * @brief Original file: minix/kernel/common/acpica/parser/pswalk.c
+ */
+#include "common/acpica/parser/pswalk.c"
+
+/**
+ * @section minix_kernel_common_acpica_parser_psxface_c
+ * @brief Original file: minix/kernel/common/acpica/parser/psxface.c
+ */
+#include "common/acpica/parser/psxface.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsaddr_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsaddr.c
+ */
+#include "common/acpica/resources/rsaddr.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rscalc_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rscalc.c
+ */
+#include "common/acpica/resources/rscalc.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rscreate_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rscreate.c
+ */
+#include "common/acpica/resources/rscreate.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsdump_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsdump.c
+ */
+#include "common/acpica/resources/rsdump.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsdumpinfo_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsdumpinfo.c
+ */
+#include "common/acpica/resources/rsdumpinfo.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsinfo_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsinfo.c
+ */
+#include "common/acpica/resources/rsinfo.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsio_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsio.c
+ */
+#include "common/acpica/resources/rsio.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsirq_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsirq.c
+ */
+#include "common/acpica/resources/rsirq.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rslist_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rslist.c
+ */
+#include "common/acpica/resources/rslist.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsmemory_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsmemory.c
+ */
+#include "common/acpica/resources/rsmemory.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsmisc_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsmisc.c
+ */
+#include "common/acpica/resources/rsmisc.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsserial_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsserial.c
+ */
+#include "common/acpica/resources/rsserial.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsutils_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsutils.c
+ */
+#include "common/acpica/resources/rsutils.c"
+
+/**
+ * @section minix_kernel_common_acpica_resources_rsxface_c
+ * @brief Original file: minix/kernel/common/acpica/resources/rsxface.c
+ */
+#include "common/acpica/resources/rsxface.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbdata_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbdata.c
+ */
+#include "common/acpica/tables/tbdata.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbfadt_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbfadt.c
+ */
+#include "common/acpica/tables/tbfadt.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbfind_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbfind.c
+ */
+#include "common/acpica/tables/tbfind.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbinstal_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbinstal.c
+ */
+#include "common/acpica/tables/tbinstal.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbprint_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbprint.c
+ */
+#include "common/acpica/tables/tbprint.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbutils_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbutils.c
+ */
+#include "common/acpica/tables/tbutils.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbxface_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbxface.c
+ */
+#include "common/acpica/tables/tbxface.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbxfload_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbxfload.c
+ */
+#include "common/acpica/tables/tbxfload.c"
+
+/**
+ * @section minix_kernel_common_acpica_tables_tbxfroot_c
+ * @brief Original file: minix/kernel/common/acpica/tables/tbxfroot.c
+ */
+#include "common/acpica/tables/tbxfroot.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utaddress_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utaddress.c
+ */
+#include "common/acpica/utilities/utaddress.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utalloc_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utalloc.c
+ */
+#include "common/acpica/utilities/utalloc.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utascii_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utascii.c
+ */
+#include "common/acpica/utilities/utascii.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utbuffer_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utbuffer.c
+ */
+#include "common/acpica/utilities/utbuffer.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utcache_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utcache.c
+ */
+#include "common/acpica/utilities/utcache.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utclib_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utclib.c
+ */
+#include "common/acpica/utilities/utclib.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utcopy_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utcopy.c
+ */
+#include "common/acpica/utilities/utcopy.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utdebug_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utdebug.c
+ */
+#include "common/acpica/utilities/utdebug.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utdecode_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utdecode.c
+ */
+#include "common/acpica/utilities/utdecode.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utdelete_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utdelete.c
+ */
+#include "common/acpica/utilities/utdelete.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_uterror_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/uterror.c
+ */
+#include "common/acpica/utilities/uterror.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_uteval_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/uteval.c
+ */
+#include "common/acpica/utilities/uteval.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utexcep_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utexcep.c
+ */
+#include "common/acpica/utilities/utexcep.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utglobal_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utglobal.c
+ */
+#include "common/acpica/utilities/utglobal.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_uthex_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/uthex.c
+ */
+#include "common/acpica/utilities/uthex.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utids_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utids.c
+ */
+#include "common/acpica/utilities/utids.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utinit_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utinit.c
+ */
+#include "common/acpica/utilities/utinit.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utlock_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utlock.c
+ */
+#include "common/acpica/utilities/utlock.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utmath_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utmath.c
+ */
+#include "common/acpica/utilities/utmath.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utmisc_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utmisc.c
+ */
+#include "common/acpica/utilities/utmisc.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utmutex_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utmutex.c
+ */
+#include "common/acpica/utilities/utmutex.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utnonansi_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utnonansi.c
+ */
+#include "common/acpica/utilities/utnonansi.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utobject_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utobject.c
+ */
+#include "common/acpica/utilities/utobject.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utosi_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utosi.c
+ */
+#include "common/acpica/utilities/utosi.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utownerid_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utownerid.c
+ */
+#include "common/acpica/utilities/utownerid.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utpredef_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utpredef.c
+ */
+#include "common/acpica/utilities/utpredef.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utresdecode_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utresdecode.c
+ */
+#include "common/acpica/utilities/utresdecode.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utresrc_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utresrc.c
+ */
+#include "common/acpica/utilities/utresrc.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utstate_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utstate.c
+ */
+#include "common/acpica/utilities/utstate.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utstring_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utstring.c
+ */
+#include "common/acpica/utilities/utstring.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utstrsuppt_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utstrsuppt.c
+ */
+#include "common/acpica/utilities/utstrsuppt.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utstrtoul64_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utstrtoul64.c
+ */
+#include "common/acpica/utilities/utstrtoul64.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_uttrack_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/uttrack.c
+ */
+#include "common/acpica/utilities/uttrack.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utuuid_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utuuid.c
+ */
+#include "common/acpica/utilities/utuuid.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utxface_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utxface.c
+ */
+#include "common/acpica/utilities/utxface.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utxferror_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utxferror.c
+ */
+#include "common/acpica/utilities/utxferror.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utxfinit_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utxfinit.c
+ */
+#include "common/acpica/utilities/utxfinit.c"
+
+/**
+ * @section minix_kernel_common_acpica_utilities_utxfmutex_c
+ * @brief Original file: minix/kernel/common/acpica/utilities/utxfmutex.c
+ */
+#include "common/acpica/utilities/utxfmutex.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_container_c
+ * @brief Original file:
+ * minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_container.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_container.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_cpu_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_cpu.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_cpu.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_device_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_device.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_device.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_dr_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_dr.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_dr.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_drv_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_drv.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_drv.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_memory_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_memory.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_memory.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_pci_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_pci.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_pci.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_resource_c
+ * @brief Original file:
+ * minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_resource.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_resource.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_scope_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_scope.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_scope.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_usbport_c
+ * @brief Original file:
+ * minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_usbport.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_usbport.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpidev_acpidev_util_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpidev/acpidev_util.c
+ */
+#include "uts/i86pc/io/acpi/acpidev/acpidev_util.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpinex_acpinex_drv_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpinex/acpinex_drv.c
+ */
+#include "uts/i86pc/io/acpi/acpinex/acpinex_drv.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_acpinex_acpinex_event_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi/acpinex/acpinex_event.c
+ */
+#include "uts/i86pc/io/acpi/acpinex/acpinex_event.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_drmach_acpi_drmach_acpi_c
+ * @brief Original file:
+ * minix/kernel/uts/i86pc/io/acpi/drmach_acpi/drmach_acpi.c
+ */
+#include "uts/i86pc/io/acpi/drmach_acpi/drmach_acpi.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_drv_acpi_drv_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi_drv/acpi_drv.c
+ */
+#include "uts/i86pc/io/acpi_drv/acpi_drv.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_drv_acpi_video_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/acpi_drv/acpi_video.c
+ */
+#include "uts/i86pc/io/acpi_drv/acpi_video.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_amd_iommu_amd_iommu_acpi_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/amd_iommu/amd_iommu_acpi.c
+ */
+#include "uts/i86pc/io/amd_iommu/amd_iommu_acpi.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_dr_dr_mem_acpi_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/dr/dr_mem_acpi.c
+ */
+#include "uts/i86pc/io/dr/dr_mem_acpi.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_hpet_acpi_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/hpet_acpi.c
+ */
+#include "uts/i86pc/io/hpet_acpi.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_ppm_acpippm_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/ppm/acpippm.c
+ */
+#include "uts/i86pc/io/ppm/acpippm.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_ppm_acpisleep_c
+ * @brief Original file: minix/kernel/uts/i86pc/io/ppm/acpisleep.c
+ */
+#include "uts/i86pc/io/ppm/acpisleep.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_os_acpi_stubs_c
+ * @brief Original file: minix/kernel/uts/i86pc/os/acpi_stubs.c
+ */
+#include "uts/i86pc/os/acpi_stubs.c"
+
+/**
+ * @section minix_kernel_uts_i86pc_os_cpupm_cpu_acpi_c
+ * @brief Original file: minix/kernel/uts/i86pc/os/cpupm/cpu_acpi.c
+ */
+#include "uts/i86pc/os/cpupm/cpu_acpi.c"
+
+/**
+ * @section minix_kernel_uts_intel_io_acpica_acpi_enum_c
+ * @brief Original file: minix/kernel/uts/intel/io/acpica/acpi_enum.c
+ */
+#include "uts/intel/io/acpica/acpi_enum.c"
+
+/**
+ * @section minix_kernel_uts_intel_io_acpica_acpica_c
+ * @brief Original file: minix/kernel/uts/intel/io/acpica/acpica.c
+ */
+#include "uts/intel/io/acpica/acpica.c"
+
+/**
+ * @section minix_kernel_uts_intel_io_acpica_acpica_ec_c
+ * @brief Original file: minix/kernel/uts/intel/io/acpica/acpica_ec.c
+ */
+#include "uts/intel/io/acpica/acpica_ec.c"
+
+/**
+ * @section minix_kernel_uts_intel_io_acpica_ahids_c
+ * @brief Original file: minix/kernel/uts/intel/io/acpica/ahids.c
+ */
+#include "uts/intel/io/acpica/ahids.c"
+
+/**
+ * @section minix_kernel_uts_intel_io_acpica_isapnp_devs_c
+ * @brief Original file: minix/kernel/uts/intel/io/acpica/isapnp_devs.c
+ */
+#include "uts/intel/io/acpica/isapnp_devs.c"
+
+/**
+ * @section minix_kernel_uts_intel_io_acpica_osl_c
+ * @brief Original file: minix/kernel/uts/intel/io/acpica/osl.c
+ */
+#include "uts/intel/io/acpica/osl.c"
+
+/**
+ * @section minix_kernel_uts_intel_io_pciex_hotplug_pciehpc_acpi_c
+ * @brief Original file: minix/kernel/uts/intel/io/pciex/hotplug/pciehpc_acpi.c
+ */
+#include "uts/intel/io/pciex/hotplug/pciehpc_acpi.c"
+
+/**
+ * @section minix_kernel_uts_intel_io_pciex_pcie_acpi_c
+ * @brief Original file: minix/kernel/uts/intel/io/pciex/pcie_acpi.c
+ */
+#include "uts/intel/io/pciex/pcie_acpi.c"
+
+/**
+ * @section minix_lib_fm_topo_modules_common_usb_topo_usb_acpi_c
+ * @brief Original file: minix/lib/fm/topo/modules/common/usb/topo_usb_acpi.c
+ */
+#include "../lib/fm/topo/modules/common/usb/topo_usb_acpi.c"
+
+/**
+ * @section minix_lib_libacpi_acpi_c
+ * @brief Original file: minix/lib/libacpi/acpi.c
+ */
+#include "../lib/libacpi/acpi.c"

--- a/minix/kernel/include/acpi_unified.h
+++ b/minix/kernel/include/acpi_unified.h
@@ -1,815 +1,1003 @@
 /**
  * @file acpi_unified.h
- * @brief Consolidated ACPI header files for analysis.
+ * @brief Aggregated ACPI headers for unified analysis.
  */
 
+#ifndef __ACPI_UNIFIED_H__
+#define __ACPI_UNIFIED_H__
+
 /**
- * @section drivers_power_acpi_acpi_globals_h
+ * @section minix_drivers_power_acpi_acpi_globals_h
  * @brief Original file: minix/drivers/power/acpi/acpi_globals.h
  */
-#ifndef __ACPI_GLOBALS_H__
-#define __ACPI_GLOBALS_H__
-
-EXTERN int acpi_enabled;
-EXTERN struct machine machine;
-
-#endif /* __ACPI_GLOBALS_H__ */
+#include "../../drivers/power/acpi/acpi_globals.h"
 
 /**
- * @section kernel_arch_i386_acpi_h
- * @brief Original file: minix/kernel/arch/i386/acpi.h
- */
-#ifndef __ACPI_H__
-#define __ACPI_H__
-
-#include "kernel/kernel.h"
-
-// Added kernel headers (precautionary for consistency)
-#include <klib/include/kmemory.h>
-#include <klib/include/kprintf.h>
-#include <klib/include/kstring.h>
-#include <minix/kernel_types.h>
-
-/* ACPI root system description pointer */
-struct acpi_rsdp {
-  char signature[8]; /* must be "RSD PTR " */
-  u8_t checksum;
-  char oemid[6];
-  u8_t revision;
-  u32_t rsdt_addr;
-  u32_t length;
-};
-
-#define ACPI_SDT_SIGNATURE_LEN 4
-
-#define ACPI_SDT_SIGNATURE(name) #name
-
-/* header common to all system description tables */
-struct acpi_sdt_header {
-  char signature[ACPI_SDT_SIGNATURE_LEN];
-  u32_t length;
-  u8_t revision;
-  u8_t checksum;
-  char oemid[6];
-  char oem_table_id[8];
-  u32_t oem_revision;
-  u32_t creator_id;
-  u32_t creator_revision;
-};
-
-struct acpi_generic_address {
-  u8_t address_space_id;
-  u8_t register_bit_width;
-  u8_t register_bit_offset;
-  u8_t access_size;
-  u64_t address;
-};
-
-struct acpi_fadt_header {
-  struct acpi_sdt_header hdr;
-  u32_t facs;
-  u32_t dsdt;
-  u8_t model;
-  u8_t preferred_pm_profile;
-  u16_t sci_int;
-  u32_t smi_cmd;
-  u8_t acpi_enable;
-  u8_t acpi_disable;
-  u8_t s4bios_req;
-  u8_t pstate_cnt;
-  u32_t pm1a_evt_blk;
-  u32_t pm1b_evt_blk;
-  u32_t pm1a_cnt_blk;
-  u32_t pm1b_cnt_blk;
-  u32_t pm2_cnt_blk;
-  u32_t pm_tmr_blk;
-  u32_t gpe0_blk;
-  u32_t gpe1_blk;
-  u8_t pm1_evt_len;
-  u8_t pm1_cnt_len;
-  u8_t pm2_cnt_len;
-  u8_t pm_tmr_len;
-  u8_t gpe0_blk_len;
-  u8_t gpe1_blk_len;
-  u8_t gpe1_base;
-  u8_t cst_cnt;
-  u16_t p_lvl2_lat;
-  u16_t p_lvl3_lat;
-  u16_t flush_size;
-  u16_t flush_stride;
-  u8_t duty_offset;
-  u8_t duty_width;
-  u8_t day_alrm;
-  u8_t mon_alrm;
-  u8_t century;
-  u16_t iapc_boot_arch;
-  u8_t reserved1;
-  u32_t flags;
-  struct acpi_generic_address reset_reg;
-  u8_t reset_value;
-  u8_t reserved2[3];
-  u64_t xfacs;
-  u64_t xdsdt;
-  struct acpi_generic_address xpm1a_evt_blk;
-  struct acpi_generic_address xpm1b_evt_blk;
-  struct acpi_generic_address xpm1a_cnt_blk;
-  struct acpi_generic_address xpm1b_cnt_blk;
-  struct acpi_generic_address xpm2_cnt_blk;
-  struct acpi_generic_address xpm_tmr_blk;
-  struct acpi_generic_address xgpe0_blk;
-  struct acpi_generic_address xgpe1_blk;
-};
-
-struct acpi_madt_hdr {
-  struct acpi_sdt_header hdr;
-  u32_t local_apic_address;
-  u32_t flags;
-};
-
-#define ACPI_MADT_TYPE_LAPIC 0
-#define ACPI_MADT_TYPE_IOAPIC 1
-#define ACPI_MADT_TYPE_INT_SRC 2
-#define ACPI_MADT_TYPE_NMI_SRC 3
-#define ACPI_MADT_TYPE_LAPIC_NMI 4
-#define ACPI_MADT_TYPE_LAPIC_ADRESS 5
-#define ACPI_MADT_TYPE_IOSAPIC 6
-#define ACPI_MADT_TYPE_LSAPIC 7
-#define ACPI_MADT_TYPE_PLATFORM_INT_SRC 8
-#define ACPI_MADT_TYPE_Lx2APIC 9
-#define ACPI_MADT_TYPE_Lx2APIC_NMI 10
-
-struct acpi_madt_item_hdr {
-  u8_t type;
-  u8_t length;
-};
-
-struct acpi_madt_lapic {
-  struct acpi_madt_item_hdr hdr;
-  u8_t acpi_cpu_id;
-  u8_t apic_id;
-  u32_t flags;
-};
-
-struct acpi_madt_ioapic {
-  struct acpi_madt_item_hdr hdr;
-  u8_t id;
-  u8_t __reserved;
-  u32_t address;
-  u32_t global_int_base;
-};
-
-struct acpi_madt_int_src {
-  struct acpi_madt_item_hdr hdr;
-  u8_t bus;
-  u8_t bus_int;
-  u32_t global_int;
-  u16_t mps_flags;
-};
-
-struct acpi_madt_nmi {
-  struct acpi_madt_item_hdr hdr;
-  u16_t flags;
-  u32_t global_int;
-};
-
-void acpi_init(void);
-
-void acpi_poweroff(void);
-
-/*
- * Returns a pointer to the io acpi structure in the MADT table in ACPI. The
- * pointer is valid only until paging is turned off. No memory is allocated in
- * this function thus no memory needs to be freed
- */
-struct acpi_madt_ioapic *acpi_get_ioapic_next(void);
-/* same as above for local APICs */
-struct acpi_madt_lapic *acpi_get_lapic_next(void);
-
-#endif /* __ACPI_H__ */
-
-/**
- * @section kernel_uts_i86pc_sys_acpidev_impl_h
- * @brief Original file: minix/kernel/uts/i86pc/sys/acpidev_impl.h
- */
-/*
- * CDDL HEADER START
- *
- * The contents of this file are subject to the terms of the
- * Common Development and Distribution License (the "License").
- * You may not use this file except in compliance with the License.
- *
- * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
- * or http://www.opensolaris.org/os/licensing.
- * See the License for the specific language governing permissions
- * and limitations under the License.
- *
- * When distributing Covered Code, include this CDDL HEADER in each
- * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
- * If applicable, add the following below this CDDL HEADER, with the
- * fields enclosed by brackets "[]" replaced with your own identifying
- * information: Portions Copyright [yyyy] [name of copyright owner]
- *
- * CDDL HEADER END
- */
-/*
- * Copyright (c) 2009-2010, Intel Corporation.
- * All rights reserved.
- */
-
-#ifndef _SYS_ACPIDEV_IMPL_H
-#define _SYS_ACPIDEV_IMPL_H
-#include <sys/acpi/acpi.h>
-#include <sys/acpica.h>
-#include <sys/acpidev.h>
-#include <sys/acpidev_dr.h>
-#include <sys/bitmap.h>
-#include <sys/cmn_err.h>
-#include <sys/sunddi.h>
-#include <sys/synch.h>
-#include <sys/types.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef _KERNEL
-
-#define ACPIDEV_ARRAY_PARAM(a) (a), (sizeof(a) / sizeof((a)[0]))
-
-/* Debug support facilities. */
-extern int acpidev_debug;
-#define ACPIDEV_DEBUG(lvl, ...)                                                \
-  if (acpidev_debug)                                                           \
-  cmn_err((lvl), __VA_ARGS__)
-
-/* Data attached to an ACPI object to maintain device status information. */
-struct acpidev_data_impl {
-  uint32_t aod_eflag; /* External flags */
-  uint32_t aod_iflag; /* Internal flags */
-  uint32_t aod_level;
-  int aod_status; /* Cached _STA value */
-  ACPI_HANDLE *aod_hdl;
-  dev_info_t *aod_dip;
-  acpidev_class_t *aod_class;
-  acpidev_class_list_t **aod_class_list;
-  acpidev_board_type_t aod_bdtype; /* Type of board. */
-  uint32_t aod_bdnum;              /* Board # for DR. */
-  uint32_t aod_portid;             /* Port id for DR. */
-  uint32_t aod_bdidx;              /* Index # of AP */
-  volatile uint32_t aod_chidx;     /* Index # of child */
-  uint32_t aod_memidx;             /* Index # of memory */
-  acpidev_class_id_t aod_class_id; /* Dev type for DR. */
-};
-
-#define ACPIDEV_ODF_STATUS_VALID 0x1
-#define ACPIDEV_ODF_DEVINFO_CREATED 0x2
-#define ACPIDEV_ODF_DEVINFO_TAGGED 0x4
-#define ACPIDEV_ODF_HOTPLUG_CAPABLE 0x100
-#define ACPIDEV_ODF_HOTPLUG_READY 0x200
-#define ACPIDEV_ODF_HOTPLUG_FAILED 0x400
-
-#define ACPIDEV_DR_IS_BOARD(hdl)                                               \
-  ((hdl)->aod_iflag & ACPIDEV_ODF_HOTPLUG_CAPABLE)
-
-#define ACPIDEV_DR_SET_BOARD(hdl)                                              \
-  (hdl)->aod_iflag |= ACPIDEV_ODF_HOTPLUG_CAPABLE
-
-#define ACPIDEV_DR_IS_READY(hdl) ((hdl)->aod_iflag & ACPIDEV_ODF_HOTPLUG_READY)
-
-#define ACPIDEV_DR_SET_READY(hdl) (hdl)->aod_iflag |= ACPIDEV_ODF_HOTPLUG_READY
-
-#define ACPIDEV_DR_IS_FAILED(hdl)                                              \
-  ((hdl)->aod_iflag & ACPIDEV_ODF_HOTPLUG_FAILED)
-
-#define ACPIDEV_DR_SET_FAILED(hdl)                                             \
-  (hdl)->aod_iflag |= ACPIDEV_ODF_HOTPLUG_FAILED
-
-#define ACPIDEV_DR_IS_WORKING(hdl)                                             \
-  (((hdl)->aod_iflag &                                                         \
-    (ACPIDEV_ODF_HOTPLUG_READY | ACPIDEV_ODF_HOTPLUG_FAILED)) ==               \
-   ACPIDEV_ODF_HOTPLUG_READY)
-
-#define ACPIDEV_DR_IS_PROCESSED(hdl)                                           \
-  ((hdl)->aod_iflag &                                                          \
-   (ACPIDEV_ODF_HOTPLUG_READY | ACPIDEV_ODF_HOTPLUG_FAILED |                   \
-    ACPIDEV_ODF_HOTPLUG_CAPABLE))
-
-#define ACPIDEV_DR_BOARD_READY(hdl)                                            \
-  (((hdl)->aod_iflag &                                                         \
-    (ACPIDEV_ODF_HOTPLUG_READY | ACPIDEV_ODF_HOTPLUG_CAPABLE)) ==              \
-   (ACPIDEV_ODF_HOTPLUG_READY | ACPIDEV_ODF_HOTPLUG_CAPABLE))
-
-/*
- * List of registered device class drivers.
- * Class drivers on the same list will be called from head to tail in turn.
- */
-struct acpidev_class_list {
-  acpidev_class_list_t *acl_next;
-  acpidev_class_t *acl_class;
-};
-
-typedef struct acpidev_pseudo_uid {
-  struct acpidev_pseudo_uid *apu_next;
-  char *apu_uid;
-  acpidev_class_id_t apu_cid;
-  uint_t apu_nid;
-} acpidev_pseudo_uid_t;
-
-typedef struct acpidev_pseudo_uid_head {
-  kmutex_t apuh_lock;
-  uint32_t apuh_id;
-  acpidev_pseudo_uid_t *apuh_first;
-} acpidev_pseudo_uid_head_t;
-
-typedef struct acpidev_dr_capacity {
-  uint_t cpu_vendor;
-  uint_t cpu_family;
-  uint_t cpu_model_min;
-  uint_t cpu_model_max;
-  uint_t cpu_step_min;
-  uint_t cpu_step_max;
-  boolean_t hotplug_supported;
-  uint64_t memory_alignment;
-} acpidev_dr_capacity_t;
-
-extern int acpidev_dr_enable;
-extern krwlock_t acpidev_class_lock;
-extern ulong_t acpidev_object_type_mask[BT_BITOUL(ACPI_TYPE_NS_NODE_MAX + 1)];
-extern ACPI_TABLE_SRAT *acpidev_srat_tbl_ptr;
-extern ACPI_TABLE_SLIT *acpidev_slit_tbl_ptr;
-
-#endif /* _KERNEL */
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* _SYS_ACPIDEV_IMPL_H */
-
-/**
- * @section drivers_power_acpi_include_acapps_h
+ * @section minix_drivers_power_acpi_include_acapps_h
  * @brief Original file: minix/drivers/power/acpi/include/acapps.h
  */
-/******************************************************************************
- *
- * Module Name: acapps - common include for ACPI applications/tools
- *
- *****************************************************************************/
-
-/*
- * Copyright (C) 2000 - 2014, Intel Corp.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions, and the following disclaimer,
- *    without modification.
- * 2. Redistributions in binary form must reproduce at minimum a disclaimer
- *    substantially similar to the "NO WARRANTY" disclaimer below
- *    ("Disclaimer") and any redistribution must be conditioned upon
- *    including a substantially similar Disclaimer requirement for further
- *    binary redistribution.
- * 3. Neither the names of the above-listed copyright holders nor the names
- *    of any contributors may be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * Alternatively, this software may be distributed under the terms of the
- * GNU General Public License ("GPL") version 2 as published by the Free
- * Software Foundation.
- *
- * NO WARRANTY
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * HOLDERS OR CONTRIBUTORS BE LIABLE FOR SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGES.
- */
-
-#ifndef _ACAPPS
-#define _ACAPPS
-
-#ifdef _MSC_VER /* disable some level-4 warnings */
-#pragma warning(                                                               \
-    disable : 4100) /* warning C4100: unreferenced formal parameter */
-#endif
-
-/* Common info for tool signons */
-
-#define ACPICA_NAME "Intel ACPI Component Architecture"
-#define ACPICA_COPYRIGHT "Copyright (c) 2000 - 2014 Intel Corporation"
-
-#if ACPI_MACHINE_WIDTH == 64
-#define ACPI_WIDTH "-64"
-
-#elif ACPI_MACHINE_WIDTH == 32
-#define ACPI_WIDTH "-32"
-
-#else
-#error unknown ACPI_MACHINE_WIDTH
-#define ACPI_WIDTH "-??"
-
-#endif
-
-/* Macros for signons and file headers */
-
-#define ACPI_COMMON_SIGNON(UtilityName)                                        \
-  "\n%s\n%s version %8.8X%s [%s]\n%s\n\n", ACPICA_NAME, UtilityName,           \
-      ((UINT32)ACPI_CA_VERSION), ACPI_WIDTH, __DATE__, ACPICA_COPYRIGHT
-
-#define ACPI_COMMON_HEADER(UtilityName, Prefix)                                \
-  "%s%s\n%s%s version %8.8X%s [%s]\n%s%s\n%s\n", Prefix, ACPICA_NAME, Prefix,  \
-      UtilityName, ((UINT32)ACPI_CA_VERSION), ACPI_WIDTH, __DATE__, Prefix,    \
-      ACPICA_COPYRIGHT, Prefix
-
-/* Macros for usage messages */
-
-#define ACPI_USAGE_HEADER(Usage) AcpiOsPrintf("Usage: %s\nOptions:\n", Usage);
-
-#define ACPI_USAGE_TEXT(Description) AcpiOsPrintf(Description);
-
-#define ACPI_OPTION(Name, Description)                                         \
-  AcpiOsPrintf("  %-18s%s\n", Name, Description);
-
-#define FILE_SUFFIX_DISASSEMBLY "dsl"
-#define ACPI_TABLE_FILE_SUFFIX ".dat"
-
-/*
- * getopt
- */
-int AcpiGetopt(int argc, char **argv, char *opts);
-
-int AcpiGetoptArgument(int argc, char **argv);
-
-extern int AcpiGbl_Optind;
-extern int AcpiGbl_Opterr;
-extern int AcpiGbl_SubOptChar;
-extern char *AcpiGbl_Optarg;
-
-/*
- * cmfsize - Common get file size function
- */
-UINT32
-CmGetFileSize(ACPI_FILE File);
-
-#ifndef ACPI_DUMP_APP
-/*
- * adisasm
- */
-ACPI_STATUS
-AdAmlDisassemble(BOOLEAN OutToFile, char *Filename, char *Prefix,
-                 char **OutFilename);
-
-void AdPrintStatistics(void);
-
-ACPI_STATUS
-AdFindDsdt(UINT8 **DsdtPtr, UINT32 *DsdtLength);
-
-void AdDumpTables(void);
-
-ACPI_STATUS
-AdGetLocalTables(void);
-
-ACPI_STATUS
-AdParseTable(ACPI_TABLE_HEADER *Table, ACPI_OWNER_ID *OwnerId,
-             BOOLEAN LoadTable, BOOLEAN External);
-
-ACPI_STATUS
-AdDisplayTables(char *Filename, ACPI_TABLE_HEADER *Table);
-
-ACPI_STATUS
-AdDisplayStatistics(void);
-
-/*
- * adwalk
- */
-void AcpiDmCrossReferenceNamespace(ACPI_PARSE_OBJECT *ParseTreeRoot,
-                                   ACPI_NAMESPACE_NODE *NamespaceRoot,
-                                   ACPI_OWNER_ID OwnerId);
-
-void AcpiDmDumpTree(ACPI_PARSE_OBJECT *Origin);
-
-void AcpiDmFindOrphanMethods(ACPI_PARSE_OBJECT *Origin);
-
-void AcpiDmFinishNamespaceLoad(ACPI_PARSE_OBJECT *ParseTreeRoot,
-                               ACPI_NAMESPACE_NODE *NamespaceRoot,
-                               ACPI_OWNER_ID OwnerId);
-
-void AcpiDmConvertResourceIndexes(ACPI_PARSE_OBJECT *ParseTreeRoot,
-                                  ACPI_NAMESPACE_NODE *NamespaceRoot);
-
-/*
- * adfile
- */
-ACPI_STATUS
-AdInitialize(void);
-
-char *FlGenerateFilename(char *InputFilename, char *Suffix);
-
-ACPI_STATUS
-FlSplitInputPathname(char *InputPath, char **OutDirectoryPath,
-                     char **OutFilename);
-
-char *AdGenerateFilename(char *Prefix, char *TableId);
-
-void AdWriteTable(ACPI_TABLE_HEADER *Table, UINT32 Length, char *TableName,
-                  char *OemTableId);
-#endif
-
-#endif /* _ACAPPS */
+#include "../../drivers/power/acpi/include/acapps.h"
 
 /**
- * @section drivers_power_acpi_include_acbuffer_h
+ * @section minix_drivers_power_acpi_include_acbuffer_h
  * @brief Original file: minix/drivers/power/acpi/include/acbuffer.h
  */
-/******************************************************************************
- *
- * Name: acbuffer.h - Support for buffers returned by ACPI predefined names
- *
- *****************************************************************************/
+#include "../../drivers/power/acpi/include/acbuffer.h"
 
-/*
- * Copyright (C) 2000 - 2014, Intel Corp.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions, and the following disclaimer,
- *    without modification.
- * 2. Redistributions in binary form must reproduce at minimum a disclaimer
- *    substantially similar to the "NO WARRANTY" disclaimer below
- *    ("Disclaimer") and any redistribution must be conditioned upon
- *    including a substantially similar Disclaimer requirement for further
- *    binary redistribution.
- * 3. Neither the names of the above-listed copyright holders nor the names
- *    of any contributors may be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * Alternatively, this software may be distributed under the terms of the
- * GNU General Public License ("GPL") version 2 as published by the Free
- * Software Foundation.
- *
- * NO WARRANTY
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * HOLDERS OR CONTRIBUTORS BE LIABLE FOR SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGES.
+/**
+ * @section minix_drivers_power_acpi_include_accommon_h
+ * @brief Original file: minix/drivers/power/acpi/include/accommon.h
  */
+#include "../../drivers/power/acpi/include/accommon.h"
 
-#ifndef __ACBUFFER_H__
-#define __ACBUFFER_H__
-
-/*
- * Contains buffer structures for these predefined names:
- * _FDE, _GRT, _GTM, _PLD, _SRT
+/**
+ * @section minix_drivers_power_acpi_include_acconfig_h
+ * @brief Original file: minix/drivers/power/acpi/include/acconfig.h
  */
+#include "../../drivers/power/acpi/include/acconfig.h"
 
-/*
- * Note: C bitfields are not used for this reason:
- *
- * "Bitfields are great and easy to read, but unfortunately the C language
- * does not specify the layout of bitfields in memory, which means they are
- * essentially useless for dealing with packed data in on-disk formats or
- * binary wire protocols." (Or ACPI tables and buffers.) "If you ask me,
- * this decision was a design error in C. Ritchie could have picked an order
- * and stuck with it." Norman Ramsey.
- * See http://stackoverflow.com/a/1053662/41661
+/**
+ * @section minix_drivers_power_acpi_include_acdebug_h
+ * @brief Original file: minix/drivers/power/acpi/include/acdebug.h
  */
+#include "../../drivers/power/acpi/include/acdebug.h"
 
-/* _FDE return value */
-
-typedef struct acpi_fde_info {
-  UINT32 Floppy0;
-  UINT32 Floppy1;
-  UINT32 Floppy2;
-  UINT32 Floppy3;
-  UINT32 Tape;
-
-} ACPI_FDE_INFO;
-
-/*
- * _GRT return value
- * _SRT input value
+/**
+ * @section minix_drivers_power_acpi_include_acdisasm_h
+ * @brief Original file: minix/drivers/power/acpi/include/acdisasm.h
  */
-typedef struct acpi_grt_info {
-  UINT16 Year;
-  UINT8 Month;
-  UINT8 Day;
-  UINT8 Hour;
-  UINT8 Minute;
-  UINT8 Second;
-  UINT8 Valid;
-  UINT16 Milliseconds;
-  UINT16 Timezone;
-  UINT8 Daylight;
-  UINT8 Reserved[3];
+#include "../../drivers/power/acpi/include/acdisasm.h"
 
-} ACPI_GRT_INFO;
-
-/* _GTM return value */
-
-typedef struct acpi_gtm_info {
-  UINT32 PioSpeed0;
-  UINT32 DmaSpeed0;
-  UINT32 PioSpeed1;
-  UINT32 DmaSpeed1;
-  UINT32 Flags;
-
-} ACPI_GTM_INFO;
-
-/*
- * Formatted _PLD return value. The minimum size is a package containing
- * one buffer.
- * Revision 1: Buffer is 16 bytes (128 bits)
- * Revision 2: Buffer is 20 bytes (160 bits)
- *
- * Note: This structure is returned from the AcpiDecodePldBuffer
- * interface.
+/**
+ * @section minix_drivers_power_acpi_include_acdispat_h
+ * @brief Original file: minix/drivers/power/acpi/include/acdispat.h
  */
-typedef struct acpi_pld_info {
-  UINT8 Revision;
-  UINT8 IgnoreColor;
-  UINT8 Red;
-  UINT8 Green;
-  UINT8 Blue;
-  UINT16 Width;
-  UINT16 Height;
-  UINT8 UserVisible;
-  UINT8 Dock;
-  UINT8 Lid;
-  UINT8 Panel;
-  UINT8 VerticalPosition;
-  UINT8 HorizontalPosition;
-  UINT8 Shape;
-  UINT8 GroupOrientation;
-  UINT8 GroupToken;
-  UINT8 GroupPosition;
-  UINT8 Bay;
-  UINT8 Ejectable;
-  UINT8 OspmEjectRequired;
-  UINT8 CabinetNumber;
-  UINT8 CardCageNumber;
-  UINT8 Reference;
-  UINT8 Rotation;
-  UINT8 Order;
-  UINT8 Reserved;
-  UINT16 VerticalOffset;
-  UINT16 HorizontalOffset;
+#include "../../drivers/power/acpi/include/acdispat.h"
 
-} ACPI_PLD_INFO;
-
-/*
- * Macros to:
- *     1) Convert a _PLD buffer to internal ACPI_PLD_INFO format - ACPI_PLD_GET*
- *        (Used by AcpiDecodePldBuffer)
- *     2) Construct a _PLD buffer - ACPI_PLD_SET*
- *        (Intended for BIOS use only)
+/**
+ * @section minix_drivers_power_acpi_include_acevents_h
+ * @brief Original file: minix/drivers/power/acpi/include/acevents.h
  */
-#define ACPI_PLD_REV1_BUFFER_SIZE                                              \
-  16 /* For Revision 1 of the buffer (From ACPI spec) */
-#define ACPI_PLD_BUFFER_SIZE                                                   \
-  20 /* For Revision 2 of the buffer (From ACPI spec) */
+#include "../../drivers/power/acpi/include/acevents.h"
 
-/* First 32-bit dword, bits 0:32 */
+/**
+ * @section minix_drivers_power_acpi_include_acexcep_h
+ * @brief Original file: minix/drivers/power/acpi/include/acexcep.h
+ */
+#include "../../drivers/power/acpi/include/acexcep.h"
 
-#define ACPI_PLD_GET_REVISION(dword) ACPI_GET_BITS(dword, 0, ACPI_7BIT_MASK)
-#define ACPI_PLD_SET_REVISION(dword, value)                                    \
-  ACPI_SET_BITS(dword, 0, ACPI_7BIT_MASK, value) /* Offset 0, Len 7 */
+/**
+ * @section minix_drivers_power_acpi_include_acglobal_h
+ * @brief Original file: minix/drivers/power/acpi/include/acglobal.h
+ */
+#include "../../drivers/power/acpi/include/acglobal.h"
 
-#define ACPI_PLD_GET_IGNORE_COLOR(dword) ACPI_GET_BITS(dword, 7, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_IGNORE_COLOR(dword, value)                                \
-  ACPI_SET_BITS(dword, 7, ACPI_1BIT_MASK, value) /* Offset 7, Len 1 */
+/**
+ * @section minix_drivers_power_acpi_include_achware_h
+ * @brief Original file: minix/drivers/power/acpi/include/achware.h
+ */
+#include "../../drivers/power/acpi/include/achware.h"
 
-#define ACPI_PLD_GET_RED(dword) ACPI_GET_BITS(dword, 8, ACPI_8BIT_MASK)
-#define ACPI_PLD_SET_RED(dword, value)                                         \
-  ACPI_SET_BITS(dword, 8, ACPI_8BIT_MASK, value) /* Offset 8, Len 8 */
+/**
+ * @section minix_drivers_power_acpi_include_acinterp_h
+ * @brief Original file: minix/drivers/power/acpi/include/acinterp.h
+ */
+#include "../../drivers/power/acpi/include/acinterp.h"
 
-#define ACPI_PLD_GET_GREEN(dword) ACPI_GET_BITS(dword, 16, ACPI_8BIT_MASK)
-#define ACPI_PLD_SET_GREEN(dword, value)                                       \
-  ACPI_SET_BITS(dword, 16, ACPI_8BIT_MASK, value) /* Offset 16, Len 8 */
+/**
+ * @section minix_drivers_power_acpi_include_aclocal_h
+ * @brief Original file: minix/drivers/power/acpi/include/aclocal.h
+ */
+#include "../../drivers/power/acpi/include/aclocal.h"
 
-#define ACPI_PLD_GET_BLUE(dword) ACPI_GET_BITS(dword, 24, ACPI_8BIT_MASK)
-#define ACPI_PLD_SET_BLUE(dword, value)                                        \
-  ACPI_SET_BITS(dword, 24, ACPI_8BIT_MASK, value) /* Offset 24, Len 8 */
+/**
+ * @section minix_drivers_power_acpi_include_acmacros_h
+ * @brief Original file: minix/drivers/power/acpi/include/acmacros.h
+ */
+#include "../../drivers/power/acpi/include/acmacros.h"
 
-/* Second 32-bit dword, bits 33:63 */
+/**
+ * @section minix_drivers_power_acpi_include_acnames_h
+ * @brief Original file: minix/drivers/power/acpi/include/acnames.h
+ */
+#include "../../drivers/power/acpi/include/acnames.h"
 
-#define ACPI_PLD_GET_WIDTH(dword) ACPI_GET_BITS(dword, 0, ACPI_16BIT_MASK)
-#define ACPI_PLD_SET_WIDTH(dword, value)                                       \
-  ACPI_SET_BITS(dword, 0, ACPI_16BIT_MASK, value) /* Offset 32+0=32, Len 16 */
+/**
+ * @section minix_drivers_power_acpi_include_acnamesp_h
+ * @brief Original file: minix/drivers/power/acpi/include/acnamesp.h
+ */
+#include "../../drivers/power/acpi/include/acnamesp.h"
 
-#define ACPI_PLD_GET_HEIGHT(dword) ACPI_GET_BITS(dword, 16, ACPI_16BIT_MASK)
-#define ACPI_PLD_SET_HEIGHT(dword, value)                                      \
-  ACPI_SET_BITS(dword, 16, ACPI_16BIT_MASK, value) /* Offset 32+16=48, Len 16  \
-                                                    */
+/**
+ * @section minix_drivers_power_acpi_include_acobject_h
+ * @brief Original file: minix/drivers/power/acpi/include/acobject.h
+ */
+#include "../../drivers/power/acpi/include/acobject.h"
 
-/* Third 32-bit dword, bits 64:95 */
+/**
+ * @section minix_drivers_power_acpi_include_acopcode_h
+ * @brief Original file: minix/drivers/power/acpi/include/acopcode.h
+ */
+#include "../../drivers/power/acpi/include/acopcode.h"
 
-#define ACPI_PLD_GET_USER_VISIBLE(dword) ACPI_GET_BITS(dword, 0, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_USER_VISIBLE(dword, value)                                \
-  ACPI_SET_BITS(dword, 0, ACPI_1BIT_MASK, value) /* Offset 64+0=64, Len 1 */
+/**
+ * @section minix_drivers_power_acpi_include_acoutput_h
+ * @brief Original file: minix/drivers/power/acpi/include/acoutput.h
+ */
+#include "../../drivers/power/acpi/include/acoutput.h"
 
-#define ACPI_PLD_GET_DOCK(dword) ACPI_GET_BITS(dword, 1, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_DOCK(dword, value)                                        \
-  ACPI_SET_BITS(dword, 1, ACPI_1BIT_MASK, value) /* Offset 64+1=65, Len 1 */
+/**
+ * @section minix_drivers_power_acpi_include_acparser_h
+ * @brief Original file: minix/drivers/power/acpi/include/acparser.h
+ */
+#include "../../drivers/power/acpi/include/acparser.h"
 
-#define ACPI_PLD_GET_LID(dword) ACPI_GET_BITS(dword, 2, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_LID(dword, value)                                         \
-  ACPI_SET_BITS(dword, 2, ACPI_1BIT_MASK, value) /* Offset 64+2=66, Len 1 */
+/**
+ * @section minix_drivers_power_acpi_include_acpi_h
+ * @brief Original file: minix/drivers/power/acpi/include/acpi.h
+ */
+#include "../../drivers/power/acpi/include/acpi.h"
 
-#define ACPI_PLD_GET_PANEL(dword) ACPI_GET_BITS(dword, 3, ACPI_3BIT_MASK)
-#define ACPI_PLD_SET_PANEL(dword, value)                                       \
-  ACPI_SET_BITS(dword, 3, ACPI_3BIT_MASK, value) /* Offset 64+3=67, Len 3 */
+/**
+ * @section minix_drivers_power_acpi_include_acpiosxf_h
+ * @brief Original file: minix/drivers/power/acpi/include/acpiosxf.h
+ */
+#include "../../drivers/power/acpi/include/acpiosxf.h"
 
-#define ACPI_PLD_GET_VERTICAL(dword) ACPI_GET_BITS(dword, 6, ACPI_2BIT_MASK)
-#define ACPI_PLD_SET_VERTICAL(dword, value)                                    \
-  ACPI_SET_BITS(dword, 6, ACPI_2BIT_MASK, value) /* Offset 64+6=70, Len 2 */
+/**
+ * @section minix_drivers_power_acpi_include_acpixf_h
+ * @brief Original file: minix/drivers/power/acpi/include/acpixf.h
+ */
+#include "../../drivers/power/acpi/include/acpixf.h"
 
-#define ACPI_PLD_GET_HORIZONTAL(dword) ACPI_GET_BITS(dword, 8, ACPI_2BIT_MASK)
-#define ACPI_PLD_SET_HORIZONTAL(dword, value)                                  \
-  ACPI_SET_BITS(dword, 8, ACPI_2BIT_MASK, value) /* Offset 64+8=72, Len 2 */
+/**
+ * @section minix_drivers_power_acpi_include_acpredef_h
+ * @brief Original file: minix/drivers/power/acpi/include/acpredef.h
+ */
+#include "../../drivers/power/acpi/include/acpredef.h"
 
-#define ACPI_PLD_GET_SHAPE(dword) ACPI_GET_BITS(dword, 10, ACPI_4BIT_MASK)
-#define ACPI_PLD_SET_SHAPE(dword, value)                                       \
-  ACPI_SET_BITS(dword, 10, ACPI_4BIT_MASK, value) /* Offset 64+10=74, Len 4 */
+/**
+ * @section minix_drivers_power_acpi_include_acresrc_h
+ * @brief Original file: minix/drivers/power/acpi/include/acresrc.h
+ */
+#include "../../drivers/power/acpi/include/acresrc.h"
 
-#define ACPI_PLD_GET_ORIENTATION(dword) ACPI_GET_BITS(dword, 14, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_ORIENTATION(dword, value)                                 \
-  ACPI_SET_BITS(dword, 14, ACPI_1BIT_MASK, value) /* Offset 64+14=78, Len 1 */
+/**
+ * @section minix_drivers_power_acpi_include_acrestyp_h
+ * @brief Original file: minix/drivers/power/acpi/include/acrestyp.h
+ */
+#include "../../drivers/power/acpi/include/acrestyp.h"
 
-#define ACPI_PLD_GET_TOKEN(dword) ACPI_GET_BITS(dword, 15, ACPI_8BIT_MASK)
-#define ACPI_PLD_SET_TOKEN(dword, value)                                       \
-  ACPI_SET_BITS(dword, 15, ACPI_8BIT_MASK, value) /* Offset 64+15=79, Len 8 */
+/**
+ * @section minix_drivers_power_acpi_include_acstruct_h
+ * @brief Original file: minix/drivers/power/acpi/include/acstruct.h
+ */
+#include "../../drivers/power/acpi/include/acstruct.h"
 
-#define ACPI_PLD_GET_POSITION(dword) ACPI_GET_BITS(dword, 23, ACPI_8BIT_MASK)
-#define ACPI_PLD_SET_POSITION(dword, value)                                    \
-  ACPI_SET_BITS(dword, 23, ACPI_8BIT_MASK, value) /* Offset 64+23=87, Len 8 */
+/**
+ * @section minix_drivers_power_acpi_include_actables_h
+ * @brief Original file: minix/drivers/power/acpi/include/actables.h
+ */
+#include "../../drivers/power/acpi/include/actables.h"
 
-#define ACPI_PLD_GET_BAY(dword) ACPI_GET_BITS(dword, 31, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_BAY(dword, value)                                         \
-  ACPI_SET_BITS(dword, 31, ACPI_1BIT_MASK, value) /* Offset 64+31=95, Len 1 */
+/**
+ * @section minix_drivers_power_acpi_include_actbl_h
+ * @brief Original file: minix/drivers/power/acpi/include/actbl.h
+ */
+#include "../../drivers/power/acpi/include/actbl.h"
 
-/* Fourth 32-bit dword, bits 96:127 */
+/**
+ * @section minix_drivers_power_acpi_include_actbl1_h
+ * @brief Original file: minix/drivers/power/acpi/include/actbl1.h
+ */
+#include "../../drivers/power/acpi/include/actbl1.h"
 
-#define ACPI_PLD_GET_EJECTABLE(dword) ACPI_GET_BITS(dword, 0, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_EJECTABLE(dword, value)                                   \
-  ACPI_SET_BITS(dword, 0, ACPI_1BIT_MASK, value) /* Offset 96+0=96, Len 1 */
+/**
+ * @section minix_drivers_power_acpi_include_actbl2_h
+ * @brief Original file: minix/drivers/power/acpi/include/actbl2.h
+ */
+#include "../../drivers/power/acpi/include/actbl2.h"
 
-#define ACPI_PLD_GET_OSPM_EJECT(dword) ACPI_GET_BITS(dword, 1, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_OSPM_EJECT(dword, value)                                  \
-  ACPI_SET_BITS(dword, 1, ACPI_1BIT_MASK, value) /* Offset 96+1=97, Len 1 */
+/**
+ * @section minix_drivers_power_acpi_include_actbl3_h
+ * @brief Original file: minix/drivers/power/acpi/include/actbl3.h
+ */
+#include "../../drivers/power/acpi/include/actbl3.h"
 
-#define ACPI_PLD_GET_CABINET(dword) ACPI_GET_BITS(dword, 2, ACPI_8BIT_MASK)
-#define ACPI_PLD_SET_CABINET(dword, value)                                     \
-  ACPI_SET_BITS(dword, 2, ACPI_8BIT_MASK, value) /* Offset 96+2=98, Len 8 */
+/**
+ * @section minix_drivers_power_acpi_include_actypes_h
+ * @brief Original file: minix/drivers/power/acpi/include/actypes.h
+ */
+#include "../../drivers/power/acpi/include/actypes.h"
 
-#define ACPI_PLD_GET_CARD_CAGE(dword) ACPI_GET_BITS(dword, 10, ACPI_8BIT_MASK)
-#define ACPI_PLD_SET_CARD_CAGE(dword, value)                                   \
-  ACPI_SET_BITS(dword, 10, ACPI_8BIT_MASK, value) /* Offset 96+10=106, Len 8   \
-                                                   */
+/**
+ * @section minix_drivers_power_acpi_include_acutils_h
+ * @brief Original file: minix/drivers/power/acpi/include/acutils.h
+ */
+#include "../../drivers/power/acpi/include/acutils.h"
 
-#define ACPI_PLD_GET_REFERENCE(dword) ACPI_GET_BITS(dword, 18, ACPI_1BIT_MASK)
-#define ACPI_PLD_SET_REFERENCE(dword, value)                                   \
-  ACPI_SET_BITS(dword, 18, ACPI_1BIT_MASK, value) /* Offset 96+18=114, Len 1   \
-                                                   */
+/**
+ * @section minix_drivers_power_acpi_include_amlcode_h
+ * @brief Original file: minix/drivers/power/acpi/include/amlcode.h
+ */
+#include "../../drivers/power/acpi/include/amlcode.h"
 
-#define ACPI_PLD_GET_ROTATION(dword) ACPI_GET_BITS(dword, 19, ACPI_4BIT_MASK)
-#define ACPI_PLD_SET_ROTATION(dword, value)                                    \
-  ACPI_SET_BITS(dword, 19, ACPI_4BIT_MASK, value) /* Offset 96+19=115, Len 4   \
-                                                   */
+/**
+ * @section minix_drivers_power_acpi_include_amlresrc_h
+ * @brief Original file: minix/drivers/power/acpi/include/amlresrc.h
+ */
+#include "../../drivers/power/acpi/include/amlresrc.h"
 
-#define ACPI_PLD_GET_ORDER(dword) ACPI_GET_BITS(dword, 23, ACPI_5BIT_MASK)
-#define ACPI_PLD_SET_ORDER(dword, value)                                       \
-  ACPI_SET_BITS(dword, 23, ACPI_5BIT_MASK, value) /* Offset 96+23=119, Len 5   \
-                                                   */
+/**
+ * @section minix_drivers_power_acpi_include_platform_accygwin_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/accygwin.h
+ */
+#include "../../drivers/power/acpi/include/platform/accygwin.h"
 
-/* Fifth 32-bit dword, bits 128:159 (Revision 2 of _PLD only) */
+/**
+ * @section minix_drivers_power_acpi_include_platform_acefi_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acefi.h
+ */
+#include "../../drivers/power/acpi/include/platform/acefi.h"
 
-#define ACPI_PLD_GET_VERT_OFFSET(dword) ACPI_GET_BITS(dword, 0, ACPI_16BIT_MASK)
-#define ACPI_PLD_SET_VERT_OFFSET(dword, value)                                 \
-  ACPI_SET_BITS(dword, 0, ACPI_16BIT_MASK, value) /* Offset 128+0=128, Len 16  \
-                                                   */
+/**
+ * @section minix_drivers_power_acpi_include_platform_acenvex_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acenvex.h
+ */
+#include "../../drivers/power/acpi/include/platform/acenvex.h"
 
-#define ACPI_PLD_GET_HORIZ_OFFSET(dword)                                       \
-  ACPI_GET_BITS(dword, 16, ACPI_16BIT_MASK)
-#define ACPI_PLD_SET_HORIZ_OFFSET(dword, value)                                \
-  ACPI_SET_BITS(dword, 16, ACPI_16BIT_MASK,                                    \
-                value) /* Offset 128+16=144, Len 16 */
+/**
+ * @section minix_drivers_power_acpi_include_platform_acfreebsd_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acfreebsd.h
+ */
+#include "../../drivers/power/acpi/include/platform/acfreebsd.h"
 
-#endif /* ACBUFFER_H */
+/**
+ * @section minix_drivers_power_acpi_include_platform_acgcc_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acgcc.h
+ */
+#include "../../drivers/power/acpi/include/platform/acgcc.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_achaiku_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/achaiku.h
+ */
+#include "../../drivers/power/acpi/include/platform/achaiku.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_acintel_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acintel.h
+ */
+#include "../../drivers/power/acpi/include/platform/acintel.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_aclinux_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/aclinux.h
+ */
+#include "../../drivers/power/acpi/include/platform/aclinux.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_aclinuxex_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/aclinuxex.h
+ */
+#include "../../drivers/power/acpi/include/platform/aclinuxex.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_acmacosx_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acmacosx.h
+ */
+#include "../../drivers/power/acpi/include/platform/acmacosx.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_acminix_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acminix.h
+ */
+#include "../../drivers/power/acpi/include/platform/acminix.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_acmsvc_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acmsvc.h
+ */
+#include "../../drivers/power/acpi/include/platform/acmsvc.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_acos2_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acos2.h
+ */
+#include "../../drivers/power/acpi/include/platform/acos2.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_acwin_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acwin.h
+ */
+#include "../../drivers/power/acpi/include/platform/acwin.h"
+
+/**
+ * @section minix_drivers_power_acpi_include_platform_acwin64_h
+ * @brief Original file: minix/drivers/power/acpi/include/platform/acwin64.h
+ */
+#include "../../drivers/power/acpi/include/platform/acwin64.h"
+
+/**
+ * @section minix_drivers_power_acpi_pci_h
+ * @brief Original file: minix/drivers/power/acpi/pci.h
+ */
+#include "../../drivers/power/acpi/pci.h"
+
+/**
+ * @section minix_include_minix_acpi_h
+ * @brief Original file: minix/include/minix/acpi.h
+ */
+#include "../../include/minix/acpi.h"
+
+/**
+ * @section minix_kernel_arch_i386_acpi_h
+ * @brief Original file: minix/kernel/arch/i386/acpi.h
+ */
+#include "../arch/i386/acpi.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_Guid_Acpi_h
+ * @brief Original file: minix/kernel/boot/efi/include/Guid/Acpi.h
+ */
+#include "../boot/efi/include/Guid/Acpi.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi10_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi10.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi10.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi20_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi20.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi20.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi30_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi30.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi30.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi40_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi40.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi40.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi50_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi50.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi50.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi51_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi51.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi51.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi60_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi60.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi60.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi61_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi61.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi61.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi62_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi62.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi62.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi63_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi63.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi63.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_Acpi64_h
+ * @brief Original file: minix/kernel/boot/efi/include/IndustryStandard/Acpi64.h
+ */
+#include "../boot/efi/include/IndustryStandard/Acpi64.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_IndustryStandard_AcpiAml_h
+ * @brief Original file:
+ * minix/kernel/boot/efi/include/IndustryStandard/AcpiAml.h
+ */
+#include "../boot/efi/include/IndustryStandard/AcpiAml.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_Protocol_IsaAcpi_h
+ * @brief Original file: minix/kernel/boot/efi/include/Protocol/IsaAcpi.h
+ */
+#include "../boot/efi/include/Protocol/IsaAcpi.h"
+
+/**
+ * @section minix_kernel_boot_efi_include_Uefi_UefiAcpiDataTable_h
+ * @brief Original file: minix/kernel/boot/efi/include/Uefi/UefiAcpiDataTable.h
+ */
+#include "../boot/efi/include/Uefi/UefiAcpiDataTable.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpidump_acpidump_h
+ * @brief Original file: minix/kernel/cmd/acpi/acpidump/acpidump.h
+ */
+#include "../cmd/acpi/acpidump/acpidump.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_acpixtract_acpixtract_h
+ * @brief Original file: minix/kernel/cmd/acpi/acpixtract/acpixtract.h
+ */
+#include "../cmd/acpi/acpixtract/acpixtract.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslcompiler_h
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslcompiler.h
+ */
+#include "../cmd/acpi/iasl/aslcompiler.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asldefine_h
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asldefine.h
+ */
+#include "../cmd/acpi/iasl/asldefine.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslglobal_h
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslglobal.h
+ */
+#include "../cmd/acpi/iasl/aslglobal.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_aslmessages_h
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/aslmessages.h
+ */
+#include "../cmd/acpi/iasl/aslmessages.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_asltypes_h
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/asltypes.h
+ */
+#include "../cmd/acpi/iasl/asltypes.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dtcompiler_h
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dtcompiler.h
+ */
+#include "../cmd/acpi/iasl/dtcompiler.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_dttemplate_h
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/dttemplate.h
+ */
+#include "../cmd/acpi/iasl/dttemplate.h"
+
+/**
+ * @section minix_kernel_cmd_acpi_iasl_preprocess_h
+ * @brief Original file: minix/kernel/cmd/acpi/iasl/preprocess.h
+ */
+#include "../cmd/acpi/iasl/preprocess.h"
+
+/**
+ * @section minix_kernel_cmd_bhyve_common_acpi_h
+ * @brief Original file: minix/kernel/cmd/bhyve/common/acpi.h
+ */
+#include "../cmd/bhyve/common/acpi.h"
+
+/**
+ * @section minix_kernel_cmd_bhyve_common_acpi_device_h
+ * @brief Original file: minix/kernel/cmd/bhyve/common/acpi_device.h
+ */
+#include "../cmd/bhyve/common/acpi_device.h"
+
+/**
+ * @section minix_kernel_cmd_hal_hald_solaris_devinfo_acpi_h
+ * @brief Original file: minix/kernel/cmd/hal/hald/solaris/devinfo_acpi.h
+ */
+#include "../cmd/hal/hald/solaris/devinfo_acpi.h"
+
+/**
+ * @section minix_kernel_cmd_hal_utils_acpi_h
+ * @brief Original file: minix/kernel/cmd/hal/utils/acpi.h
+ */
+#include "../cmd/hal/utils/acpi.h"
+
+/**
+ * @section minix_kernel_compat_bhyve_contrib_dev_acpica_include_acpi_h
+ * @brief Original file:
+ * minix/kernel/compat/bhyve/contrib/dev/acpica/include/acpi.h
+ */
+#include "../compat/bhyve/contrib/dev/acpica/include/acpi.h"
+
+/**
+ * @section minix_kernel_contrib_bhyve_dev_acpica_acpi_hpet_h
+ * @brief Original file: minix/kernel/contrib/bhyve/dev/acpica/acpi_hpet.h
+ */
+#include "../contrib/bhyve/dev/acpica/acpi_hpet.h"
+
+/**
+ * @section minix_kernel_uts_common_sys_acpi_drv_h
+ * @brief Original file: minix/kernel/uts/common/sys/acpi_drv.h
+ */
+#include "../uts/common/sys/acpi_drv.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_acpi_drmach_acpi_drmach_acpi_h
+ * @brief Original file:
+ * minix/kernel/uts/i86pc/io/acpi/drmach_acpi/drmach_acpi.h
+ */
+#include "../uts/i86pc/io/acpi/drmach_acpi/drmach_acpi.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_io_amd_iommu_amd_iommu_acpi_h
+ * @brief Original file: minix/kernel/uts/i86pc/io/amd_iommu/amd_iommu_acpi.h
+ */
+#include "../uts/i86pc/io/amd_iommu/amd_iommu_acpi.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_sys_acpidev_h
+ * @brief Original file: minix/kernel/uts/i86pc/sys/acpidev.h
+ */
+#include "../uts/i86pc/sys/acpidev.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_sys_acpidev_dr_h
+ * @brief Original file: minix/kernel/uts/i86pc/sys/acpidev_dr.h
+ */
+#include "../uts/i86pc/sys/acpidev_dr.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_sys_acpidev_impl_h
+ * @brief Original file: minix/kernel/uts/i86pc/sys/acpidev_impl.h
+ */
+#include "../uts/i86pc/sys/acpidev_impl.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_sys_acpidev_rsc_h
+ * @brief Original file: minix/kernel/uts/i86pc/sys/acpidev_rsc.h
+ */
+#include "../uts/i86pc/sys/acpidev_rsc.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_sys_acpinex_h
+ * @brief Original file: minix/kernel/uts/i86pc/sys/acpinex.h
+ */
+#include "../uts/i86pc/sys/acpinex.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_sys_cpu_acpi_h
+ * @brief Original file: minix/kernel/uts/i86pc/sys/cpu_acpi.h
+ */
+#include "../uts/i86pc/sys/cpu_acpi.h"
+
+/**
+ * @section minix_kernel_uts_i86pc_sys_hpet_acpi_h
+ * @brief Original file: minix/kernel/uts/i86pc/sys/hpet_acpi.h
+ */
+#include "../uts/i86pc/sys/hpet_acpi.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acapps_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acapps.h
+ */
+#include "../uts/intel/sys/acpi/acapps.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acbuffer_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acbuffer.h
+ */
+#include "../uts/intel/sys/acpi/acbuffer.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acclib_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acclib.h
+ */
+#include "../uts/intel/sys/acpi/acclib.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_accommon_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/accommon.h
+ */
+#include "../uts/intel/sys/acpi/accommon.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acconfig_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acconfig.h
+ */
+#include "../uts/intel/sys/acpi/acconfig.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acconvert_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acconvert.h
+ */
+#include "../uts/intel/sys/acpi/acconvert.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acdebug_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acdebug.h
+ */
+#include "../uts/intel/sys/acpi/acdebug.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acdisasm_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acdisasm.h
+ */
+#include "../uts/intel/sys/acpi/acdisasm.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acdispat_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acdispat.h
+ */
+#include "../uts/intel/sys/acpi/acdispat.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acevents_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acevents.h
+ */
+#include "../uts/intel/sys/acpi/acevents.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acexcep_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acexcep.h
+ */
+#include "../uts/intel/sys/acpi/acexcep.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acglobal_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acglobal.h
+ */
+#include "../uts/intel/sys/acpi/acglobal.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_achware_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/achware.h
+ */
+#include "../uts/intel/sys/acpi/achware.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acinterp_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acinterp.h
+ */
+#include "../uts/intel/sys/acpi/acinterp.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_aclocal_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/aclocal.h
+ */
+#include "../uts/intel/sys/acpi/aclocal.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acmacros_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acmacros.h
+ */
+#include "../uts/intel/sys/acpi/acmacros.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acnames_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acnames.h
+ */
+#include "../uts/intel/sys/acpi/acnames.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acnamesp_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acnamesp.h
+ */
+#include "../uts/intel/sys/acpi/acnamesp.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acobject_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acobject.h
+ */
+#include "../uts/intel/sys/acpi/acobject.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acopcode_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acopcode.h
+ */
+#include "../uts/intel/sys/acpi/acopcode.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acoutput_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acoutput.h
+ */
+#include "../uts/intel/sys/acpi/acoutput.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acparser_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acparser.h
+ */
+#include "../uts/intel/sys/acpi/acparser.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acpi_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acpi.h
+ */
+#include "../uts/intel/sys/acpi/acpi.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acpi_enum_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acpi_enum.h
+ */
+#include "../uts/intel/sys/acpi/acpi_enum.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acpi_pci_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acpi_pci.h
+ */
+#include "../uts/intel/sys/acpi/acpi_pci.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acpiosxf_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acpiosxf.h
+ */
+#include "../uts/intel/sys/acpi/acpiosxf.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acpixf_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acpixf.h
+ */
+#include "../uts/intel/sys/acpi/acpixf.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acpredef_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acpredef.h
+ */
+#include "../uts/intel/sys/acpi/acpredef.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acresrc_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acresrc.h
+ */
+#include "../uts/intel/sys/acpi/acresrc.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acrestyp_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acrestyp.h
+ */
+#include "../uts/intel/sys/acpi/acrestyp.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acstruct_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acstruct.h
+ */
+#include "../uts/intel/sys/acpi/acstruct.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_actables_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/actables.h
+ */
+#include "../uts/intel/sys/acpi/actables.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_actbinfo_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/actbinfo.h
+ */
+#include "../uts/intel/sys/acpi/actbinfo.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_actbl_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/actbl.h
+ */
+#include "../uts/intel/sys/acpi/actbl.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_actbl1_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/actbl1.h
+ */
+#include "../uts/intel/sys/acpi/actbl1.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_actbl2_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/actbl2.h
+ */
+#include "../uts/intel/sys/acpi/actbl2.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_actbl3_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/actbl3.h
+ */
+#include "../uts/intel/sys/acpi/actbl3.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_actypes_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/actypes.h
+ */
+#include "../uts/intel/sys/acpi/actypes.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acutils_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acutils.h
+ */
+#include "../uts/intel/sys/acpi/acutils.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_acuuid_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/acuuid.h
+ */
+#include "../uts/intel/sys/acpi/acuuid.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_amlcode_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/amlcode.h
+ */
+#include "../uts/intel/sys/acpi/amlcode.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_amlresrc_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/amlresrc.h
+ */
+#include "../uts/intel/sys/acpi/amlresrc.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_accygwin_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/accygwin.h
+ */
+#include "../uts/intel/sys/acpi/platform/accygwin.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acdragonfly_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acdragonfly.h
+ */
+#include "../uts/intel/sys/acpi/platform/acdragonfly.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acdragonflyex_h
+ * @brief Original file:
+ * minix/kernel/uts/intel/sys/acpi/platform/acdragonflyex.h
+ */
+#include "../uts/intel/sys/acpi/platform/acdragonflyex.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acefi_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acefi.h
+ */
+#include "../uts/intel/sys/acpi/platform/acefi.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acefiex_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acefiex.h
+ */
+#include "../uts/intel/sys/acpi/platform/acefiex.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acenv_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acenv.h
+ */
+#include "../uts/intel/sys/acpi/platform/acenv.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acenvex_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acenvex.h
+ */
+#include "../uts/intel/sys/acpi/platform/acenvex.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acfreebsd_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acfreebsd.h
+ */
+#include "../uts/intel/sys/acpi/platform/acfreebsd.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acgcc_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acgcc.h
+ */
+#include "../uts/intel/sys/acpi/platform/acgcc.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acgccex_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acgccex.h
+ */
+#include "../uts/intel/sys/acpi/platform/acgccex.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_achaiku_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/achaiku.h
+ */
+#include "../uts/intel/sys/acpi/platform/achaiku.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acintel_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acintel.h
+ */
+#include "../uts/intel/sys/acpi/platform/acintel.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_aclinux_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/aclinux.h
+ */
+#include "../uts/intel/sys/acpi/platform/aclinux.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_aclinuxex_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/aclinuxex.h
+ */
+#include "../uts/intel/sys/acpi/platform/aclinuxex.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acmacosx_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acmacosx.h
+ */
+#include "../uts/intel/sys/acpi/platform/acmacosx.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acmsvc_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acmsvc.h
+ */
+#include "../uts/intel/sys/acpi/platform/acmsvc.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acmsvcex_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acmsvcex.h
+ */
+#include "../uts/intel/sys/acpi/platform/acmsvcex.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acnetbsd_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acnetbsd.h
+ */
+#include "../uts/intel/sys/acpi/platform/acnetbsd.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acos2_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acos2.h
+ */
+#include "../uts/intel/sys/acpi/platform/acos2.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acqnx_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acqnx.h
+ */
+#include "../uts/intel/sys/acpi/platform/acqnx.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acsolaris_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acsolaris.h
+ */
+#include "../uts/intel/sys/acpi/platform/acsolaris.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acwin_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acwin.h
+ */
+#include "../uts/intel/sys/acpi/platform/acwin.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpi_platform_acwin64_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpi/platform/acwin64.h
+ */
+#include "../uts/intel/sys/acpi/platform/acwin64.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_acpica_h
+ * @brief Original file: minix/kernel/uts/intel/sys/acpica.h
+ */
+#include "../uts/intel/sys/acpica.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_hotplug_pci_pciehpc_acpi_h
+ * @brief Original file: minix/kernel/uts/intel/sys/hotplug/pci/pciehpc_acpi.h
+ */
+#include "../uts/intel/sys/hotplug/pci/pciehpc_acpi.h"
+
+/**
+ * @section minix_kernel_uts_intel_sys_pcie_acpi_h
+ * @brief Original file: minix/kernel/uts/intel/sys/pcie_acpi.h
+ */
+#include "../uts/intel/sys/pcie_acpi.h"
+
+#endif /* __ACPI_UNIFIED_H__ */


### PR DESCRIPTION
## Summary
- rebuild `acpi_unified.c` and `acpi_unified.h`
- list every ACPI-related `.c` and `.h` file and include them with Doxygen sections
- format unified sources with `clang-format`

## Testing
- `clang-format -i minix/kernel/acpi_unified.c minix/kernel/include/acpi_unified.h`

------
https://chatgpt.com/codex/tasks/task_e_684b68e09088833196214f28c53ab3ec

## Summary by Sourcery

Aggregate ACPI sources by replacing inline merged code with include directives and update unified headers accordingly

Enhancements:
- Replace manual concatenation of ACPI code with #include directives for each ACPI source file in acpi_unified.c
- Include all ACPI-related headers in acpi_unified.h organized under Doxygen sections
- Rename Doxygen section identifiers to use consistent minix_ prefixes
- Reformat acpi_unified.c and acpi_unified.h with clang-format