### PR TITLE
Refactor dinode duplication

### DIFF
--- a/libos/fs.h
+++ b/libos/fs.h
@@ -4,9 +4,8 @@
 // On-disk file system format.
 // Both the kernel and user programs use this header file.
 
-
-#define ROOTINO 1  // root i-number
-#define BSIZE 512  // block size
+#define ROOTINO 1 // root i-number
+#define BSIZE 512 // block size
 
 // Disk layout:
 // [ boot block | super block | log | inode blocks |
@@ -15,40 +14,48 @@
 // mkfs computes the super block and builds an initial file system. The
 // super block describes the disk layout:
 struct superblock {
-  uint32_t size;         // Size of file system image (blocks)
-  uint32_t nblocks;      // Number of data blocks
-  uint32_t ninodes;      // Number of inodes.
-  uint32_t nlog;         // Number of log blocks
-  uint32_t logstart;     // Block number of first log block
-  uint32_t inodestart;   // Block number of first inode block
-  uint32_t bmapstart;    // Block number of first free map block
+  uint32_t size;       // Size of file system image (blocks)
+  uint32_t nblocks;    // Number of data blocks
+  uint32_t ninodes;    // Number of inodes.
+  uint32_t nlog;       // Number of log blocks
+  uint32_t logstart;   // Block number of first log block
+  uint32_t inodestart; // Block number of first inode block
+  uint32_t bmapstart;  // Block number of first free map block
 };
 
 #define NDIRECT 12
 #define NINDIRECT (BSIZE / sizeof(uint32_t))
-#define MAXFILE (NDIRECT + NINDIRECT*1024)
+#define MAXFILE (NDIRECT + NINDIRECT * 1024)
 
 // On-disk inode structure
-struct dinode {
-  short type;           // File type
-  short major;          // Major device number (T_DEV only)
-  short minor;          // Minor device number (T_DEV only)
-  short nlink;          // Number of links to inode in file system
-  uint32_t size;            // Size of file (bytes)
-  uint32_t addrs[NDIRECT+1];   // Data block addresses
-};
+/**
+ * @brief On-disk inode structure used by the minimalist file system.
+ *
+ * This mirrors the layout used by the original xv6 operating system.
+ */
+typedef struct fs_dinode {
+  short type;                  /**< File type                            */
+  short major;                 /**< Major device number (T_DEV only)    */
+  short minor;                 /**< Minor device number (T_DEV only)    */
+  short nlink;                 /**< Number of links to inode in FS      */
+  uint32_t size;               /**< File size in bytes                  */
+  uint32_t addrs[NDIRECT + 1]; /**< Data block addresses                */
+} fs_dinode;
+
+/* Backwards compatibility alias */
+#define dinode fs_dinode
 
 // Inodes per block.
-#define IPB           (BSIZE / sizeof(struct dinode))
+#define IPB (BSIZE / sizeof(struct fs_dinode))
 
 // Block containing inode i
-#define IBLOCK(i, sb)     ((i) / IPB + sb.inodestart)
+#define IBLOCK(i, sb) ((i) / IPB + sb.inodestart)
 
 // Bitmap bits per block
-#define BPB           (BSIZE*8)
+#define BPB (BSIZE * 8)
 
 // Block of free map containing bit for block b
-#define BBLOCK(b, sb) (b/BPB + sb.bmapstart)
+#define BBLOCK(b, sb) (b / BPB + sb.bmapstart)
 
 // Directory is a file containing a sequence of dirent structures.
 #define DIRSIZ 14

--- a/libos/mkfs.c
+++ b/libos/mkfs.c
@@ -1,19 +1,24 @@
+#include <assert.h>
+#include <fcntl.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <fcntl.h>
-#include <assert.h>
+#include <unistd.h>
 
-#define stat xv6_stat  // avoid clash with host struct stat
-#include "types.h"
+#define stat xv6_stat // avoid clash with host struct stat
 #include "fs.h"
-#include "stat.h"
-#include "param.h"
 #include "generic_utils.h"
+#include "param.h"
+#include "stat.h"
+#include "types.h"
 
 #ifndef static_assert
-#define static_assert(a, b) do { switch (0) case 0: case (a): ; } while (0)
+#define static_assert(a, b)                                                    \
+  do {                                                                         \
+    switch (0)                                                                 \
+    case 0:                                                                    \
+    case (a):;                                                                 \
+  } while (0)
 #endif
 
 #define NINODES 200
@@ -21,11 +26,11 @@
 // Disk layout:
 // [ boot block | sb block | log | inode blocks | free bit map | data blocks ]
 
-int nbitmap = FSSIZE/(BSIZE*8) + 1;
+int nbitmap = FSSIZE / (BSIZE * 8) + 1;
 int ninodeblocks = NINODES / IPB + 1;
 int nlog = LOGSIZE;
-int nmeta;    // Number of meta blocks (boot, sb, nlog, inode, bitmap)
-int nblocks;  // Number of data blocks
+int nmeta;   // Number of meta blocks (boot, sb, nlog, inode, bitmap)
+int nblocks; // Number of data blocks
 
 int fsfd;
 struct superblock sb;
@@ -33,31 +38,26 @@ char zeroes[BSIZE];
 uint32_t freeinode = 1;
 uint32_t freeblock;
 
-
 void balloc(int);
-void wsect(uint32_t, void*);
-void winode(uint32_t, struct dinode*);
-void rinode(uint32_t inum, struct dinode *ip);
+void wsect(uint32_t, void *);
+void winode(uint32_t, struct fs_dinode *);
+void rinode(uint32_t inum, struct fs_dinode *ip);
 void rsect(uint32_t sec, void *buf);
 uint32_t ialloc(uint16_t type);
 void iappend(uint32_t inum, void *p, int n);
 
 // convert to intel byte order
-uint16_t
-xshort(uint16_t x)
-{
+uint16_t xshort(uint16_t x) {
   uint16_t y;
-  uint8_t *a = (uint8_t*)&y;
+  uint8_t *a = (uint8_t *)&y;
   a[0] = x;
   a[1] = x >> 8;
   return y;
 }
 
-uint32_t
-xint(uint32_t x)
-{
+uint32_t xint(uint32_t x) {
   uint32_t y;
-  uint8_t *a = (uint8_t*)&y;
+  uint8_t *a = (uint8_t *)&y;
   a[0] = x;
   a[1] = x >> 8;
   a[2] = x >> 16;
@@ -65,28 +65,25 @@ xint(uint32_t x)
   return y;
 }
 
-int
-main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   int i, cc, fd;
   uint32_t rootino, inum, off;
   struct dirent de;
   char buf[BSIZE];
-  struct dinode din;
-
+  struct fs_dinode din;
 
   static_assert(sizeof(int) == 4, "Integers must be 4 bytes!");
 
-  if(argc < 2){
+  if (argc < 2) {
     fprintf(stderr, "Usage: mkfs fs.img files...\n");
     exit(1);
   }
 
-  assert((BSIZE % sizeof(struct dinode)) == 0);
+  assert((BSIZE % sizeof(struct fs_dinode)) == 0);
   assert((BSIZE % sizeof(struct dirent)) == 0);
 
-  fsfd = open(argv[1], O_RDWR|O_CREAT|O_TRUNC, 0666);
-  if(fsfd < 0){
+  fsfd = open(argv[1], O_RDWR | O_CREAT | O_TRUNC, 0666);
+  if (fsfd < 0) {
     perror(argv[1]);
     exit(1);
   }
@@ -100,15 +97,16 @@ main(int argc, char *argv[])
   sb.ninodes = xint(NINODES);
   sb.nlog = xint(nlog);
   sb.logstart = xint(2);
-  sb.inodestart = xint(2+nlog);
-  sb.bmapstart = xint(2+nlog+ninodeblocks);
+  sb.inodestart = xint(2 + nlog);
+  sb.bmapstart = xint(2 + nlog + ninodeblocks);
 
-  printf("nmeta %d (boot, super, log blocks %u inode blocks %u, bitmap blocks %u) blocks %d total %d\n",
+  printf("nmeta %d (boot, super, log blocks %u inode blocks %u, bitmap blocks "
+         "%u) blocks %d total %d\n",
          nmeta, nlog, ninodeblocks, nbitmap, nblocks, FSSIZE);
 
-  freeblock = nmeta;     // the first free block that we can allocate
+  freeblock = nmeta; // the first free block that we can allocate
 
-  for(i = 0; i < FSSIZE; i++)
+  for (i = 0; i < FSSIZE; i++)
     wsect(i, zeroes);
 
   memset(buf, 0, sizeof(buf));
@@ -128,10 +126,10 @@ main(int argc, char *argv[])
   strcpy(de.name, "..");
   iappend(rootino, &de, sizeof(de));
 
-  for(i = 2; i < argc; i++){
+  for (i = 2; i < argc; i++) {
     assert(index(argv[i], '/') == 0);
 
-    if((fd = open(argv[i], 0)) < 0){
+    if ((fd = open(argv[i], 0)) < 0) {
       perror(argv[i]);
       exit(1);
     }
@@ -140,7 +138,7 @@ main(int argc, char *argv[])
     // The binaries are named _rm, _cat, etc. to keep the
     // build operating system from trying to execute them
     // in place of system binaries like rm and cat.
-    if(argv[i][0] == '_')
+    if (argv[i][0] == '_')
       ++argv[i];
 
     inum = ialloc(T_FILE);
@@ -150,7 +148,7 @@ main(int argc, char *argv[])
     strncpy(de.name, argv[i], DIRSIZ);
     iappend(rootino, &de, sizeof(de));
 
-    while((cc = read(fd, buf, sizeof(buf))) > 0)
+    while ((cc = read(fd, buf, sizeof(buf))) > 0)
       iappend(inum, buf, cc);
 
     close(fd);
@@ -159,7 +157,7 @@ main(int argc, char *argv[])
   // fix size of root inode dir
   rinode(rootino, &din);
   off = xint(din.size);
-  off = ((off/BSIZE) + 1) * BSIZE;
+  off = ((off / BSIZE) + 1) * BSIZE;
   din.size = xint(off);
   winode(rootino, &din);
 
@@ -168,64 +166,54 @@ main(int argc, char *argv[])
   exit(0);
 }
 
-void
-wsect(uint32_t sec, void *buf)
-{
-  if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
+void wsect(uint32_t sec, void *buf) {
+  if (lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE) {
     perror("lseek");
     exit(1);
   }
-  if(write(fsfd, buf, BSIZE) != BSIZE){
+  if (write(fsfd, buf, BSIZE) != BSIZE) {
     perror("write");
     exit(1);
   }
 }
 
-void
-winode(uint32_t inum, struct dinode *ip)
-{
+void winode(uint32_t inum, struct fs_dinode *ip) {
   char buf[BSIZE];
   uint32_t bn;
-  struct dinode *dip;
+  struct fs_dinode *dip;
 
   bn = IBLOCK(inum, sb);
   rsect(bn, buf);
-  dip = ((struct dinode*)buf) + (inum % IPB);
+  dip = ((struct fs_dinode *)buf) + (inum % IPB);
   *dip = *ip;
   wsect(bn, buf);
 }
 
-void
-rinode(uint32_t inum, struct dinode *ip)
-{
+void rinode(uint32_t inum, struct fs_dinode *ip) {
   char buf[BSIZE];
   uint32_t bn;
-  struct dinode *dip;
+  struct fs_dinode *dip;
 
   bn = IBLOCK(inum, sb);
   rsect(bn, buf);
-  dip = ((struct dinode*)buf) + (inum % IPB);
+  dip = ((struct fs_dinode *)buf) + (inum % IPB);
   *ip = *dip;
 }
 
-void
-rsect(uint32_t sec, void *buf)
-{
-  if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
+void rsect(uint32_t sec, void *buf) {
+  if (lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE) {
     perror("lseek");
     exit(1);
   }
-  if(read(fsfd, buf, BSIZE) != BSIZE){
+  if (read(fsfd, buf, BSIZE) != BSIZE) {
     perror("read");
     exit(1);
   }
 }
 
-uint32_t
-ialloc(uint16_t type)
-{
+uint32_t ialloc(uint16_t type) {
   uint32_t inum = freeinode++;
-  struct dinode din;
+  struct fs_dinode din;
 
   bzero(&din, sizeof(din));
   din.type = xshort(type);
@@ -235,29 +223,24 @@ ialloc(uint16_t type)
   return inum;
 }
 
-void
-balloc(int used)
-{
+void balloc(int used) {
   uint8_t buf[BSIZE];
   int i;
 
   printf("balloc: first %d blocks have been allocated\n", used);
-  assert(used < BSIZE*8);
+  assert(used < BSIZE * 8);
   bzero(buf, BSIZE);
-  for(i = 0; i < used; i++){
-    buf[i/8] = buf[i/8] | (0x1 << (i%8));
+  for (i = 0; i < used; i++) {
+    buf[i / 8] = buf[i / 8] | (0x1 << (i % 8));
   }
   printf("balloc: write bitmap block at sector %u\n", sb.bmapstart);
   wsect(sb.bmapstart, buf);
 }
 
-
-void
-iappend(uint32_t inum, void *xp, int n)
-{
-  char *p = (char*)xp;
+void iappend(uint32_t inum, void *xp, int n) {
+  char *p = (char *)xp;
   uint32_t fbn, off, n1;
-  struct dinode din;
+  struct fs_dinode din;
   char buf[BSIZE];
   uint32_t indirect[NINDIRECT];
   uint32_t x;
@@ -265,24 +248,24 @@ iappend(uint32_t inum, void *xp, int n)
   rinode(inum, &din);
   off = xint(din.size);
   // printf("append inum %d at off %d sz %d\n", inum, off, n);
-  while(n > 0){
+  while (n > 0) {
     fbn = off / BSIZE;
     assert(fbn < MAXFILE);
-    if(fbn < NDIRECT){
-      if(xint(din.addrs[fbn]) == 0){
+    if (fbn < NDIRECT) {
+      if (xint(din.addrs[fbn]) == 0) {
         din.addrs[fbn] = xint(freeblock++);
       }
       x = xint(din.addrs[fbn]);
     } else {
-      if(xint(din.addrs[NDIRECT]) == 0){
+      if (xint(din.addrs[NDIRECT]) == 0) {
         din.addrs[NDIRECT] = xint(freeblock++);
       }
-      rsect(xint(din.addrs[NDIRECT]), (char*)indirect);
-      if(indirect[fbn - NDIRECT] == 0){
+      rsect(xint(din.addrs[NDIRECT]), (char *)indirect);
+      if (indirect[fbn - NDIRECT] == 0) {
         indirect[fbn - NDIRECT] = xint(freeblock++);
-        wsect(xint(din.addrs[NDIRECT]), (char*)indirect);
+        wsect(xint(din.addrs[NDIRECT]), (char *)indirect);
       }
-      x = xint(indirect[fbn-NDIRECT]);
+      x = xint(indirect[fbn - NDIRECT]);
     }
     n1 = GU_MIN(n, (fbn + 1) * BSIZE - off);
     rsect(x, buf);

--- a/minix/mkfs.c
+++ b/minix/mkfs.c
@@ -1,19 +1,24 @@
+#include <assert.h>
+#include <fcntl.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <fcntl.h>
-#include <assert.h>
+#include <unistd.h>
 
-#define stat xv6_stat  // avoid clash with host struct stat
-#include "types.h"
+#define stat xv6_stat // avoid clash with host struct stat
 #include "fs.h"
-#include "stat.h"
-#include "param.h"
 #include "generic_utils.h"
+#include "param.h"
+#include "stat.h"
+#include "types.h"
 
 #ifndef static_assert
-#define static_assert(a, b) do { switch (0) case 0: case (a): ; } while (0)
+#define static_assert(a, b)                                                    \
+  do {                                                                         \
+    switch (0)                                                                 \
+    case 0:                                                                    \
+    case (a):;                                                                 \
+  } while (0)
 #endif
 
 #define NINODES 200
@@ -21,11 +26,11 @@
 // Disk layout:
 // [ boot block | sb block | log | inode blocks | free bit map | data blocks ]
 
-int nbitmap = FSSIZE/(BSIZE*8) + 1;
+int nbitmap = FSSIZE / (BSIZE * 8) + 1;
 int ninodeblocks = NINODES / IPB + 1;
 int nlog = LOGSIZE;
-int nmeta;    // Number of meta blocks (boot, sb, nlog, inode, bitmap)
-int nblocks;  // Number of data blocks
+int nmeta;   // Number of meta blocks (boot, sb, nlog, inode, bitmap)
+int nblocks; // Number of data blocks
 
 int fsfd;
 struct superblock sb;
@@ -33,31 +38,26 @@ char zeroes[BSIZE];
 uint32_t freeinode = 1;
 uint32_t freeblock;
 
-
 void balloc(int);
-void wsect(uint32_t, void*);
-void winode(uint32_t, struct dinode*);
-void rinode(uint32_t inum, struct dinode *ip);
+void wsect(uint32_t, void *);
+void winode(uint32_t, struct fs_dinode *);
+void rinode(uint32_t inum, struct fs_dinode *ip);
 void rsect(uint32_t sec, void *buf);
 uint32_t ialloc(uint16_t type);
 void iappend(uint32_t inum, void *p, int n);
 
 // convert to intel byte order
-uint16_t
-xshort(uint16_t x)
-{
+uint16_t xshort(uint16_t x) {
   uint16_t y;
-  uint8_t *a = (uint8_t*)&y;
+  uint8_t *a = (uint8_t *)&y;
   a[0] = x;
   a[1] = x >> 8;
   return y;
 }
 
-uint32_t
-xint(uint32_t x)
-{
+uint32_t xint(uint32_t x) {
   uint32_t y;
-  uint8_t *a = (uint8_t*)&y;
+  uint8_t *a = (uint8_t *)&y;
   a[0] = x;
   a[1] = x >> 8;
   a[2] = x >> 16;
@@ -65,28 +65,25 @@ xint(uint32_t x)
   return y;
 }
 
-int
-main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   int i, cc, fd;
   uint32_t rootino, inum, off;
   struct dirent de;
   char buf[BSIZE];
-  struct dinode din;
-
+  struct fs_dinode din;
 
   static_assert(sizeof(int) == 4, "Integers must be 4 bytes!");
 
-  if(argc < 2){
+  if (argc < 2) {
     fprintf(stderr, "Usage: mkfs fs.img files...\n");
     exit(1);
   }
 
-  assert((BSIZE % sizeof(struct dinode)) == 0);
+  assert((BSIZE % sizeof(struct fs_dinode)) == 0);
   assert((BSIZE % sizeof(struct dirent)) == 0);
 
-  fsfd = open(argv[1], O_RDWR|O_CREAT|O_TRUNC, 0666);
-  if(fsfd < 0){
+  fsfd = open(argv[1], O_RDWR | O_CREAT | O_TRUNC, 0666);
+  if (fsfd < 0) {
     perror(argv[1]);
     exit(1);
   }
@@ -100,15 +97,16 @@ main(int argc, char *argv[])
   sb.ninodes = xint(NINODES);
   sb.nlog = xint(nlog);
   sb.logstart = xint(2);
-  sb.inodestart = xint(2+nlog);
-  sb.bmapstart = xint(2+nlog+ninodeblocks);
+  sb.inodestart = xint(2 + nlog);
+  sb.bmapstart = xint(2 + nlog + ninodeblocks);
 
-  printf("nmeta %d (boot, super, log blocks %u inode blocks %u, bitmap blocks %u) blocks %d total %d\n",
+  printf("nmeta %d (boot, super, log blocks %u inode blocks %u, bitmap blocks "
+         "%u) blocks %d total %d\n",
          nmeta, nlog, ninodeblocks, nbitmap, nblocks, FSSIZE);
 
-  freeblock = nmeta;     // the first free block that we can allocate
+  freeblock = nmeta; // the first free block that we can allocate
 
-  for(i = 0; i < FSSIZE; i++)
+  for (i = 0; i < FSSIZE; i++)
     wsect(i, zeroes);
 
   memset(buf, 0, sizeof(buf));
@@ -128,10 +126,10 @@ main(int argc, char *argv[])
   strcpy(de.name, "..");
   iappend(rootino, &de, sizeof(de));
 
-  for(i = 2; i < argc; i++){
+  for (i = 2; i < argc; i++) {
     assert(index(argv[i], '/') == 0);
 
-    if((fd = open(argv[i], 0)) < 0){
+    if ((fd = open(argv[i], 0)) < 0) {
       perror(argv[i]);
       exit(1);
     }
@@ -140,7 +138,7 @@ main(int argc, char *argv[])
     // The binaries are named _rm, _cat, etc. to keep the
     // build operating system from trying to execute them
     // in place of system binaries like rm and cat.
-    if(argv[i][0] == '_')
+    if (argv[i][0] == '_')
       ++argv[i];
 
     inum = ialloc(T_FILE);
@@ -150,7 +148,7 @@ main(int argc, char *argv[])
     strncpy(de.name, argv[i], DIRSIZ);
     iappend(rootino, &de, sizeof(de));
 
-    while((cc = read(fd, buf, sizeof(buf))) > 0)
+    while ((cc = read(fd, buf, sizeof(buf))) > 0)
       iappend(inum, buf, cc);
 
     close(fd);
@@ -159,7 +157,7 @@ main(int argc, char *argv[])
   // fix size of root inode dir
   rinode(rootino, &din);
   off = xint(din.size);
-  off = ((off/BSIZE) + 1) * BSIZE;
+  off = ((off / BSIZE) + 1) * BSIZE;
   din.size = xint(off);
   winode(rootino, &din);
 
@@ -168,64 +166,54 @@ main(int argc, char *argv[])
   exit(0);
 }
 
-void
-wsect(uint32_t sec, void *buf)
-{
-  if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
+void wsect(uint32_t sec, void *buf) {
+  if (lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE) {
     perror("lseek");
     exit(1);
   }
-  if(write(fsfd, buf, BSIZE) != BSIZE){
+  if (write(fsfd, buf, BSIZE) != BSIZE) {
     perror("write");
     exit(1);
   }
 }
 
-void
-winode(uint32_t inum, struct dinode *ip)
-{
+void winode(uint32_t inum, struct fs_dinode *ip) {
   char buf[BSIZE];
   uint32_t bn;
-  struct dinode *dip;
+  struct fs_dinode *dip;
 
   bn = IBLOCK(inum, sb);
   rsect(bn, buf);
-  dip = ((struct dinode*)buf) + (inum % IPB);
+  dip = ((struct fs_dinode *)buf) + (inum % IPB);
   *dip = *ip;
   wsect(bn, buf);
 }
 
-void
-rinode(uint32_t inum, struct dinode *ip)
-{
+void rinode(uint32_t inum, struct fs_dinode *ip) {
   char buf[BSIZE];
   uint32_t bn;
-  struct dinode *dip;
+  struct fs_dinode *dip;
 
   bn = IBLOCK(inum, sb);
   rsect(bn, buf);
-  dip = ((struct dinode*)buf) + (inum % IPB);
+  dip = ((struct fs_dinode *)buf) + (inum % IPB);
   *ip = *dip;
 }
 
-void
-rsect(uint32_t sec, void *buf)
-{
-  if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
+void rsect(uint32_t sec, void *buf) {
+  if (lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE) {
     perror("lseek");
     exit(1);
   }
-  if(read(fsfd, buf, BSIZE) != BSIZE){
+  if (read(fsfd, buf, BSIZE) != BSIZE) {
     perror("read");
     exit(1);
   }
 }
 
-uint32_t
-ialloc(uint16_t type)
-{
+uint32_t ialloc(uint16_t type) {
   uint32_t inum = freeinode++;
-  struct dinode din;
+  struct fs_dinode din;
 
   bzero(&din, sizeof(din));
   din.type = xshort(type);
@@ -235,29 +223,24 @@ ialloc(uint16_t type)
   return inum;
 }
 
-void
-balloc(int used)
-{
+void balloc(int used) {
   uint8_t buf[BSIZE];
   int i;
 
   printf("balloc: first %d blocks have been allocated\n", used);
-  assert(used < BSIZE*8);
+  assert(used < BSIZE * 8);
   bzero(buf, BSIZE);
-  for(i = 0; i < used; i++){
-    buf[i/8] = buf[i/8] | (0x1 << (i%8));
+  for (i = 0; i < used; i++) {
+    buf[i / 8] = buf[i / 8] | (0x1 << (i % 8));
   }
   printf("balloc: write bitmap block at sector %u\n", sb.bmapstart);
   wsect(sb.bmapstart, buf);
 }
 
-
-void
-iappend(uint32_t inum, void *xp, int n)
-{
-  char *p = (char*)xp;
+void iappend(uint32_t inum, void *xp, int n) {
+  char *p = (char *)xp;
   uint32_t fbn, off, n1;
-  struct dinode din;
+  struct fs_dinode din;
   char buf[BSIZE];
   uint32_t indirect[NINDIRECT];
   uint32_t x;
@@ -265,24 +248,24 @@ iappend(uint32_t inum, void *xp, int n)
   rinode(inum, &din);
   off = xint(din.size);
   // printf("append inum %d at off %d sz %d\n", inum, off, n);
-  while(n > 0){
+  while (n > 0) {
     fbn = off / BSIZE;
     assert(fbn < MAXFILE);
-    if(fbn < NDIRECT){
-      if(xint(din.addrs[fbn]) == 0){
+    if (fbn < NDIRECT) {
+      if (xint(din.addrs[fbn]) == 0) {
         din.addrs[fbn] = xint(freeblock++);
       }
       x = xint(din.addrs[fbn]);
     } else {
-      if(xint(din.addrs[NDIRECT]) == 0){
+      if (xint(din.addrs[NDIRECT]) == 0) {
         din.addrs[NDIRECT] = xint(freeblock++);
       }
-      rsect(xint(din.addrs[NDIRECT]), (char*)indirect);
-      if(indirect[fbn - NDIRECT] == 0){
+      rsect(xint(din.addrs[NDIRECT]), (char *)indirect);
+      if (indirect[fbn - NDIRECT] == 0) {
         indirect[fbn - NDIRECT] = xint(freeblock++);
-        wsect(xint(din.addrs[NDIRECT]), (char*)indirect);
+        wsect(xint(din.addrs[NDIRECT]), (char *)indirect);
       }
-      x = xint(indirect[fbn-NDIRECT]);
+      x = xint(indirect[fbn - NDIRECT]);
     }
     n1 = GU_MIN(n, (fbn + 1) * BSIZE - off);
     rsect(x, buf);


### PR DESCRIPTION
## Summary
- rename `struct dinode` in fs.h to `struct fs_dinode`
- update mkfs helpers to use the new inode type
- retain backwards compatibility via a macro alias
- run clang-format on touched sources

## Testing
- `meson setup build`
- `ninja -C build` *(fails: conflicting types in klib headers)*

------
https://chatgpt.com/codex/tasks/task_e_684b8cef0c1483318ad383d695bbf4c7

## Summary by Sourcery

Refactor the on-disk inode type to fs_dinode, update mkfs utilities to use the new type, and apply formatting improvements to the affected sources

Enhancements:
- Rename struct dinode to fs_dinode in fs.h and add a backward-compatibility alias
- Update libos and minix mkfs.c to use struct fs_dinode in all inode operations
- Apply clang-format style adjustments to whitespace and formatting across touched sources