### PR TITLE
Consolidate IOMMU/MMU sources without deleting originals

### DIFF
--- a/minix/iommu_unified.c
+++ b/minix/iommu_unified.c
@@ -1,0 +1,231 @@
+/**
+ * @file iommu_unified.c
+ * @brief Consolidated IOMMU source from multiple components.
+ *
+ * This file aggregates logic from:
+ *  - libos/iommu.c
+ *  - minix/iommu.c
+ *  - minix/kernel/iommu.c
+ *  - minix/kernel/iommu_v2.c
+ */
+
+/* ==== libos/iommu.c ==== */
+#include "iommu.h"
+#include "ipc.h"
+
+int iommu_map_call(uintptr_t iova, uintptr_t pa, size_t len) {
+  zipc_msg_t m = {0};
+  m.w0 = IOMMU_OP_MAP;
+  m.w1 = iova;
+  m.w2 = pa;
+  m.w3 = len;
+  zipc_call(&m);
+  return (int)m.w0;
+}
+
+int iommu_unmap_call(uintptr_t iova, size_t len) {
+  zipc_msg_t m = {0};
+  m.w0 = IOMMU_OP_UNMAP;
+  m.w1 = iova;
+  m.w2 = len;
+  zipc_call(&m);
+  return (int)m.w0;
+}
+
+int iommu_revoke_call(void) {
+  zipc_msg_t m = {0};
+  m.w0 = IOMMU_OP_REVOKE;
+  zipc_call(&m);
+  return (int)m.w0;
+}
+
+/* ==== minix/iommu.c ==== */
+#include "defs.h"
+#include "iommu.h"
+#include "mmu.h"
+#include <stdint.h>
+#include <string.h>
+
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa, size_t len,
+              int perm) {
+  if (!dom || !dom->pt || (iova % PGSIZE) || (pa % PGSIZE) || (len % PGSIZE))
+    return -1;
+  size_t pages = len / PGSIZE;
+  for (size_t i = 0; i < pages; i++) {
+    size_t idx = (iova / PGSIZE) + i;
+    if (idx >= dom->npages)
+      return -1;
+    if (dom->pt[idx] & IOMMU_PTE_P)
+      return -1;
+    dom->pt[idx] = (pa + i * PGSIZE) | perm | IOMMU_PTE_P;
+  }
+  iommu_sync(dom);
+  return 0;
+}
+
+int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len) {
+  if (!dom || !dom->pt || (iova % PGSIZE) || (len % PGSIZE))
+    return -1;
+  size_t pages = len / PGSIZE;
+  for (size_t i = 0; i < pages; i++) {
+    size_t idx = (iova / PGSIZE) + i;
+    if (idx >= dom->npages || !(dom->pt[idx] & IOMMU_PTE_P))
+      return -1;
+    dom->pt[idx] = 0;
+  }
+  iommu_sync(dom);
+  return 0;
+}
+
+void iommu_sync(struct iommu_dom *dom) {
+  (void)dom;
+  // In hardware this would flush IOTLB; no-op in mock implementation.
+}
+
+void iommu_revoke(struct iommu_dom *dom) {
+  if (!dom || !dom->pt)
+    return;
+  for (size_t i = 0; i < dom->npages; i++)
+    dom->pt[i] = 0;
+  iommu_sync(dom);
+}
+
+/* ==== minix/kernel/iommu.c ==== */
+#include "iommu.h"
+#include <stdlib.h>
+
+struct mapping {
+  uintptr_t iova;
+  uintptr_t pa;
+  size_t len;
+  uint32_t perms;
+  struct mapping *next;
+};
+
+static struct mapping **map_list(struct iommu_dom *d) {
+  return (struct mapping **)&d->pml_root; /* treat pml_root as list head */
+}
+
+static void tlb_invalidate_domain(uint16_t asid) { (void)asid; }
+
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa, size_t len,
+              uint32_t perms) {
+  if (!dom || !len)
+    return -1;
+  struct mapping *m = malloc(sizeof(*m));
+  if (!m)
+    return -1;
+  m->iova = iova;
+  m->pa = pa;
+  m->len = len;
+  m->perms = perms;
+  spin_lock(&dom->lock);
+  m->next = *map_list(dom);
+  *map_list(dom) = m;
+  dom->epoch++;
+  spin_unlock(&dom->lock);
+  tlb_invalidate_domain(dom->asid);
+  return 0;
+}
+
+int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len) {
+  if (!dom || !len)
+    return -1;
+  spin_lock(&dom->lock);
+  struct mapping **p = map_list(dom);
+  while (*p) {
+    if ((*p)->iova == iova && (*p)->len == len) {
+      struct mapping *tmp = *p;
+      *p = tmp->next;
+      free(tmp);
+      dom->epoch++;
+      spin_unlock(&dom->lock);
+      tlb_invalidate_domain(dom->asid);
+      return 0;
+    }
+    p = &(*p)->next;
+  }
+  spin_unlock(&dom->lock);
+  return -1;
+}
+
+int iommu_bulk_map(struct iommu_dom *dom, const uintptr_t *iovas,
+                   const uintptr_t *pas, const size_t *lens,
+                   const uint32_t *perms, size_t count) {
+  if (!dom)
+    return -1;
+  for (size_t i = 0; i < count; ++i)
+    if (iommu_map(dom, iovas[i], pas[i], lens[i], perms[i]) != 0)
+      return -1;
+  return 0;
+}
+
+/* ==== minix/kernel/iommu_v2.c ==== */
+#include "iommu_v2.h"
+#include <stdlib.h>
+
+struct mapping {
+  uintptr_t iova;
+  uintptr_t pa;
+  size_t len;
+  uint32_t perms;
+  struct mapping *next;
+};
+
+static struct mapping **map_list(struct iommu_dom *d) {
+  return (struct mapping **)&d->pml_root; /* treat pml_root as list head */
+}
+
+static void tlb_invalidate_domain(uint16_t asid) { (void)asid; }
+
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa, size_t len,
+              uint32_t perms) {
+  if (!dom || !len)
+    return -1;
+  struct mapping *m = malloc(sizeof(*m));
+  if (!m)
+    return -1;
+  m->iova = iova;
+  m->pa = pa;
+  m->len = len;
+  m->perms = perms;
+  spin_lock(&dom->lock);
+  m->next = *map_list(dom);
+  *map_list(dom) = m;
+  dom->epoch++;
+  spin_unlock(&dom->lock);
+  tlb_invalidate_domain(dom->asid);
+  return 0;
+}
+
+int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len) {
+  if (!dom || !len)
+    return -1;
+  spin_lock(&dom->lock);
+  struct mapping **p = map_list(dom);
+  while (*p) {
+    if ((*p)->iova == iova && (*p)->len == len) {
+      struct mapping *tmp = *p;
+      *p = tmp->next;
+      free(tmp);
+      dom->epoch++;
+      spin_unlock(&dom->lock);
+      tlb_invalidate_domain(dom->asid);
+      return 0;
+    }
+    p = &(*p)->next;
+  }
+  spin_unlock(&dom->lock);
+  return -1;
+}
+
+int iommu_bulk_map(struct iommu_dom *dom, const uintptr_t *iovas,
+                   const uintptr_t *pas, const size_t *lens,
+                   const uint32_t *perms, size_t count) {
+  if (!dom)
+    return -1;
+  for (size_t i = 0; i < count; ++i)
+    if (iommu_map(dom, iovas[i], pas[i], lens[i], perms[i]) != 0)
+      return -1;
+  return 0;
+}

--- a/minix/iommu_unified.h
+++ b/minix/iommu_unified.h
@@ -1,0 +1,160 @@
+/**
+ * @file iommu_unified.h
+ * @brief Consolidated IOMMU header definitions.
+ *
+ * This header aggregates declarations from:
+ *  - minix/include/iommu.h
+ *  - minix/iommu.h
+ *  - minix/kernel/iommu.h
+ *  - minix/kernel/iommu_v2.h
+ */
+
+/* ==== minix/include/iommu.h ==== */
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+#define IOMMU_PTE_P 0x1
+
+typedef uint64_t iommu_pte_t;
+
+struct iommu_dom {
+  iommu_pte_t *pt;
+  size_t npages;
+};
+
+#define IOMMU_OP_MAP 0xA0
+#define IOMMU_OP_UNMAP 0xA1
+#define IOMMU_OP_REVOKE 0xA2
+
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa, size_t len,
+              int perm);
+int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len);
+void iommu_sync(struct iommu_dom *dom);
+void iommu_revoke(struct iommu_dom *dom);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int iommu_map_call(uintptr_t iova, uintptr_t pa, size_t len);
+int iommu_unmap_call(uintptr_t iova, size_t len);
+int iommu_revoke_call(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* ==== minix/iommu.h ==== */
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+#define IOMMU_PTE_P 0x1
+
+typedef uint64_t iommu_pte_t;
+
+struct iommu_dom {
+  iommu_pte_t *pt;
+  size_t npages;
+};
+
+#define IOMMU_OP_MAP 0xA0
+#define IOMMU_OP_UNMAP 0xA1
+#define IOMMU_OP_REVOKE 0xA2
+
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa, size_t len,
+              int perm);
+int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len);
+void iommu_sync(struct iommu_dom *dom);
+void iommu_revoke(struct iommu_dom *dom);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int iommu_map_call(uintptr_t iova, uintptr_t pa, size_t len);
+int iommu_unmap_call(uintptr_t iova, size_t len);
+int iommu_revoke_call(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* ==== minix/kernel/iommu.h ==== */
+#ifndef IOMMU_H
+#define IOMMU_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef SPINLOCK_T_DEFINED
+#define SPINLOCK_T_DEFINED
+typedef struct {
+  volatile int locked;
+} spinlock_t;
+
+static inline void spin_lock_init(spinlock_t *l) { l->locked = 0; }
+static inline void spin_lock(spinlock_t *l) {
+  while (__sync_lock_test_and_set(&l->locked, 1))
+    ;
+}
+static inline void spin_unlock(spinlock_t *l) {
+  __sync_lock_release(&l->locked);
+}
+#endif
+
+struct iommu_dom {
+  uintptr_t pml_root;
+  uint16_t asid;
+  unsigned long epoch;
+  uint32_t flags;
+  spinlock_t lock;
+};
+
+int iommu_map(struct iommu_dom *, uintptr_t iova, uintptr_t pa, size_t len,
+              uint32_t perms);
+int iommu_unmap(struct iommu_dom *, uintptr_t iova, size_t len);
+int iommu_bulk_map(struct iommu_dom *, const uintptr_t *iovas,
+                   const uintptr_t *pas, const size_t *lens,
+                   const uint32_t *perms, size_t count);
+
+#endif /* IOMMU_H */
+
+/* ==== minix/kernel/iommu_v2.h ==== */
+#ifndef IOMMU_V2_H
+#define IOMMU_V2_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef SPINLOCK_T_DEFINED
+#define SPINLOCK_T_DEFINED
+typedef struct {
+  volatile int locked;
+} spinlock_t;
+
+static inline void spin_lock_init(spinlock_t *l) { l->locked = 0; }
+static inline void spin_lock(spinlock_t *l) {
+  while (__sync_lock_test_and_set(&l->locked, 1))
+    ;
+}
+static inline void spin_unlock(spinlock_t *l) {
+  __sync_lock_release(&l->locked);
+}
+#endif
+
+struct iommu_dom {
+  uintptr_t pml_root;
+  uint16_t asid;
+  unsigned long epoch;
+  uint32_t flags;
+  spinlock_t lock;
+};
+
+int iommu_map(struct iommu_dom *, uintptr_t iova, uintptr_t pa, size_t len,
+              uint32_t perms);
+int iommu_unmap(struct iommu_dom *, uintptr_t iova, size_t len);
+int iommu_bulk_map(struct iommu_dom *, const uintptr_t *iovas,
+                   const uintptr_t *pas, const size_t *lens,
+                   const uint32_t *perms, size_t count);
+
+#endif /* IOMMU_V2_H */

--- a/minix/kernel/mmu_unified.c
+++ b/minix/kernel/mmu_unified.c
@@ -1,0 +1,111 @@
+/**
+ * @file mmu_unified.c
+ * @brief Consolidated MMU source code.
+ *
+ * This file aggregates logic from:
+ *  - minix/kernel/mmu64.c
+ */
+
+/* ==== minix/kernel/mmu64.c ==== */
+#ifdef __x86_64__
+#include "defs.h"
+#include "memlayout.h"
+#include "mmu.h"
+#include "param.h"
+#include "proc.h"
+#include "types.h"
+#include <string.h>
+
+extern char data[];
+
+static pte_t *walkpml4(pml4e_t *pml4, const void *va, int alloc) {
+  pml4e_t *pml4e;
+  pdpe_t *pdp;
+  pdpe_t *pdpe;
+  pde_t *pd;
+  pte_t *pt;
+
+  pml4e = &pml4[PML4(va)];
+  if (*pml4e & PTE_P) {
+    pdp = (pdpe_t *)P2V(PTE_ADDR(*pml4e));
+  } else {
+    if (!alloc || (pdp = (pdpe_t *)kalloc()) == 0)
+      return 0;
+    memset(pdp, 0, PGSIZE);
+    *pml4e = V2P(pdp) | PTE_P | PTE_W | PTE_U;
+  }
+
+  pdpe = &pdp[PDPX(va)];
+  if (*pdpe & PTE_P) {
+    pd = (pde_t *)P2V(PTE_ADDR(*pdpe));
+  } else {
+    if (!alloc || (pd = (pde_t *)kalloc()) == 0)
+      return 0;
+    memset(pd, 0, PGSIZE);
+    *pdpe = V2P(pd) | PTE_P | PTE_W | PTE_U;
+  }
+
+  pde_t *pde = &pd[PDX(va)];
+  if (*pde & PTE_P) {
+    pt = (pte_t *)P2V(PTE_ADDR(*pde));
+  } else {
+    if (!alloc || (pt = (pte_t *)kalloc()) == 0)
+      return 0;
+    memset(pt, 0, PGSIZE);
+    *pde = V2P(pt) | PTE_P | PTE_W | PTE_U;
+  }
+
+  return &pt[PTX(va)];
+}
+
+static int mappages64(pml4e_t *pml4, void *va, uint32_t size, uint64_t pa,
+                      int perm) {
+  char *a, *last;
+  pte_t *pte;
+
+  a = (char *)PGROUNDDOWN((uintptr_t)va);
+  last = (char *)PGROUNDDOWN(((uintptr_t)va) + size - 1);
+  for (;;) {
+    if ((pte = walkpml4(pml4, a, 1)) == 0)
+      return -1;
+    if (*pte & PTE_P)
+      panic("remap");
+    *pte = pa | perm | PTE_P;
+    if (a == last)
+      break;
+    a += PGSIZE;
+    pa += PGSIZE;
+  }
+  return 0;
+}
+
+pml4e_t *setupkvm64(void) {
+  pml4e_t *pml4;
+  struct kmap {
+    void *virt;
+    uint32_t phys_start;
+    uint32_t phys_end;
+    int perm;
+  };
+  static struct kmap kmap[] = {
+      {(void *)KERNBASE, 0, EXTMEM, PTE_W},
+      {(void *)KERNLINK, V2P(KERNLINK), V2P(data), 0},
+      {(void *)data, V2P(data), PHYSTOP, PTE_W},
+      {(void *)DEVSPACE, DEVSPACE, 0, PTE_W},
+  };
+  struct kmap *k;
+
+  if ((pml4 = (pml4e_t *)kalloc()) == 0)
+    return 0;
+  memset(pml4, 0, PGSIZE);
+  if (P2V(PHYSTOP) > (void *)DEVSPACE)
+    panic("PHYSTOP too high");
+  for (k = kmap; k < &kmap[NELEM(kmap)]; k++)
+    if (mappages64(pml4, k->virt, k->phys_end - k->phys_start,
+                   (uint64_t)k->phys_start, k->perm) < 0) {
+      kfree((char *)pml4);
+      return 0;
+    }
+  return pml4;
+}
+#endif

--- a/minix/mmu_unified.h
+++ b/minix/mmu_unified.h
@@ -1,0 +1,504 @@
+/**
+ * @file mmu_unified.h
+ * @brief Consolidated MMU header definitions.
+ *
+ * This header aggregates declarations from:
+ *  - minix/include/mmu.h
+ *  - minix/kernel/mmu.h
+ */
+
+/* ==== minix/include/mmu.h ==== */
+#pragma once
+
+// This file contains definitions for the
+// x86 memory management unit (MMU).
+
+// Eflags register
+#define FL_IF 0x00000200 // Interrupt Enable
+
+// Control Register flags
+#define CR0_PE 0x00000001 // Protection Enable
+#define CR0_WP 0x00010000 // Write Protect
+#define CR0_PG 0x80000000 // Paging
+
+#define CR4_PSE 0x00000010 // Page size extension
+// Control Register CR4 bits
+#define CR4_SMEP (1 << 20) /* Supervisor Mode Execution Protection Enable */
+#define CR4_SMAP (1 << 21) /* Supervisor Mode Access Prevention Enable */
+#define CR4_UMIP (1 << 2)  /* User-Mode Instruction Prevention */
+
+// various segment selectors.
+#define SEG_KCODE 1 // kernel code
+#define SEG_KDATA 2 // kernel data+stack
+#define SEG_UCODE 3 // user code
+#define SEG_UDATA 4 // user data+stack
+#define SEG_TSS 5   // this process's task state
+
+// cpu->gdt[NSEGS] holds the above segments.
+#define NSEGS 6
+
+#ifndef __ASSEMBLER__
+// Segment Descriptor
+struct segdesc {
+  uint32_t lim_15_0 : 16;  // Low bits of segment limit
+  uint32_t base_15_0 : 16; // Low bits of segment base address
+  uint32_t base_23_16 : 8; // Middle bits of segment base address
+  uint32_t type : 4;       // Segment type (see STS_ constants)
+  uint32_t s : 1;          // 0 = system, 1 = application
+  uint32_t dpl : 2;        // Descriptor Privilege Level
+  uint32_t p : 1;          // Present
+  uint32_t lim_19_16 : 4;  // High bits of segment limit
+  uint32_t avl : 1;        // Unused (available for software use)
+  uint32_t rsv1 : 1;       // Reserved
+  uint32_t db : 1;         // 0 = 16-bit segment, 1 = 32-bit segment
+  uint32_t g : 1;          // Granularity: limit scaled by 4K when set
+  uint32_t base_31_24 : 8; // High bits of segment base address
+};
+// Ensure the descriptor is exactly 8 bytes so assembly structures match
+_Static_assert(sizeof(struct segdesc) == 8, "struct segdesc size incorrect");
+
+// Normal segment
+#define SEG(type, base, lim, dpl)                                              \
+  (struct segdesc){((lim) >> 12) & 0xffff,                                     \
+                   (uint32_t)(base) & 0xffff,                                  \
+                   ((uint32_t)(base) >> 16) & 0xff,                            \
+                   type,                                                       \
+                   1,                                                          \
+                   dpl,                                                        \
+                   1,                                                          \
+                   (uint32_t)(lim) >> 28,                                      \
+                   0,                                                          \
+                   0,                                                          \
+                   1,                                                          \
+                   1,                                                          \
+                   (uint32_t)(base) >> 24}
+#define SEG16(type, base, lim, dpl)                                            \
+  (struct segdesc){(lim) & 0xffff,                                             \
+                   (uint32_t)(base) & 0xffff,                                  \
+                   ((uint32_t)(base) >> 16) & 0xff,                            \
+                   type,                                                       \
+                   1,                                                          \
+                   dpl,                                                        \
+                   1,                                                          \
+                   (uint32_t)(lim) >> 16,                                      \
+                   0,                                                          \
+                   0,                                                          \
+                   1,                                                          \
+                   0,                                                          \
+                   (uint32_t)(base) >> 24}
+#endif
+
+#define DPL_USER 0x3 // User DPL
+
+// Application segment type bits
+#define STA_X 0x8 // Executable segment
+#define STA_W 0x2 // Writeable (non-executable segments)
+#define STA_R 0x2 // Readable (executable segments)
+
+// System segment type bits
+#define STS_T32A 0x9 // Available 32-bit TSS
+#define STS_IG32 0xE // 32-bit Interrupt Gate
+#define STS_TG32 0xF // 32-bit Trap Gate
+
+// A virtual address 'la' has a three-part structure as follows:
+//
+// +--------10------+-------10-------+---------12----------+
+// | Page Directory |   Page Table   | Offset within Page  |
+// |      Index     |      Index     |                     |
+// +----------------+----------------+---------------------+
+//  \--- PDX(va) --/ \--- PTX(va) --/
+
+// page directory index
+#ifdef __x86_64__
+#define PML4(va) (((uint64_t)(va) >> PML4SHIFT) & 0x1FF)
+#define PDPX(va) (((uint64_t)(va) >> PDPSHIFT) & 0x1FF)
+#define PDX(va) (((uint64_t)(va) >> PDSHIFT) & 0x1FF)
+#define PTX(va) (((uint64_t)(va) >> PTSHIFT) & 0x1FF)
+#else
+#define PDX(va) (((uint32_t)(va) >> PDXSHIFT) & 0x3FF)
+#define PTX(va) (((uint32_t)(va) >> PTXSHIFT) & 0x3FF)
+#endif
+
+// construct virtual address from indexes and offset
+#ifdef __x86_64__
+#define PGADDR(l4, l3, l2, l1, o)                                              \
+  ((uint64_t)((l4) << PML4SHIFT | (l3) << PDPSHIFT | (l2) << PDSHIFT |         \
+              (l1) << PTSHIFT | (o)))
+#else
+#define PGADDR(d, t, o) ((uint32_t)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
+#endif
+
+// Page directory and page table constants.
+#ifdef __x86_64__
+#define NPDENTRIES 512 // entries per page directory
+#define NPTENTRIES 512 // PTEs per page table
+#else
+#define NPDENTRIES 1024 // # directory entries per page directory
+#define NPTENTRIES 1024 // # PTEs per page table
+#endif
+#define PGSIZE 4096 // bytes mapped by a page
+
+#ifdef __x86_64__
+#define PTSHIFT 12
+#define PDSHIFT 21
+#define PDPSHIFT 30
+#define PML4SHIFT 39
+#else
+#define PTXSHIFT 12 // offset of PTX in a linear address
+#define PDXSHIFT 22 // offset of PDX in a linear address
+#endif
+
+#define PGROUNDUP(sz) (((sz) + PGSIZE - 1) & ~(PGSIZE - 1))
+#define PGROUNDDOWN(a) (((a)) & ~(PGSIZE - 1))
+
+// Page table/directory entry flags.
+#define PTE_P 0x001  // Present
+#define PTE_W 0x002  // Writeable
+#define PTE_U 0x004  // User
+#define PTE_PS 0x080 // Page Size
+
+// Permission flags for user page mappings
+#define PERM_R 0x1
+#define PERM_W 0x2
+#define PERM_X 0x4
+
+// Address in page table or page directory entry
+#ifdef __x86_64__
+#define PTE_ADDR(pte) ((uint64_t)(pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint64_t)(pte) & 0xFFF)
+#else
+#define PTE_ADDR(pte) ((uint32_t)(pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint32_t)(pte) & 0xFFF)
+#endif
+
+#ifndef __ASSEMBLER__
+#ifdef __x86_64__
+typedef uint64_t pte_t;
+typedef uint64_t pdpe_t;
+typedef uint64_t pml4e_t;
+#else
+typedef uint32_t pte_t;
+#endif
+
+// Task state segment format
+struct taskstate {
+  uint32_t link; // Old ts selector
+  uint32_t esp0; // Stack pointers and segment selectors
+  uint16_t ss0;  //   after an increase in privilege level
+  uint16_t padding1;
+  uint32_t *esp1;
+  uint16_t ss1;
+  uint16_t padding2;
+  uint32_t *esp2;
+  uint16_t ss2;
+  uint16_t padding3;
+  void *cr3;     // Page directory base
+  uint32_t *eip; // Saved state from last task switch
+  uint32_t eflags;
+  uint32_t eax; // More saved state (registers)
+  uint32_t ecx;
+  uint32_t edx;
+  uint32_t ebx;
+  uint32_t *esp;
+  uint32_t *ebp;
+  uint32_t esi;
+  uint32_t edi;
+  uint16_t es; // Even more saved state (segment selectors)
+  uint16_t padding4;
+  uint16_t cs;
+  uint16_t padding5;
+  uint16_t ss;
+  uint16_t padding6;
+  uint16_t ds;
+  uint16_t padding7;
+  uint16_t fs;
+  uint16_t padding8;
+  uint16_t gs;
+  uint16_t padding9;
+  uint16_t ldt;
+  uint16_t padding10;
+  uint16_t t;    // Trap on task switch
+  uint16_t iomb; // I/O map base address
+};
+
+// Gate descriptors for interrupts and traps
+struct gatedesc {
+  uint32_t off_15_0 : 16;  // low 16 bits of offset in segment
+  uint32_t cs : 16;        // code segment selector
+  uint32_t args : 5;       // # args, 0 for interrupt/trap gates
+  uint32_t rsv1 : 3;       // reserved(should be zero I guess)
+  uint32_t type : 4;       // type(STS_{IG32,TG32})
+  uint32_t s : 1;          // must be 0 (system)
+  uint32_t dpl : 2;        // descriptor(meaning new) privilege level
+  uint32_t p : 1;          // Present
+  uint32_t off_31_16 : 16; // high bits of offset in segment
+};
+
+// Set up a normal interrupt/trap gate descriptor.
+// - istrap: 1 for a trap (= exception) gate, 0 for an interrupt gate.
+//   interrupt gate clears FL_IF, trap gate leaves FL_IF alone
+// - sel: Code segment selector for interrupt/trap handler
+// - off: Offset in code segment for interrupt/trap handler
+// - dpl: Descriptor Privilege Level -
+//        the privilege level required for software to invoke
+//        this interrupt/trap gate explicitly using an int instruction.
+#define SETGATE(gate, istrap, sel, off, d)                                     \
+  {                                                                            \
+    (gate).off_15_0 = (uint32_t)(off) & 0xffff;                                \
+    (gate).cs = (sel);                                                         \
+    (gate).args = 0;                                                           \
+    (gate).rsv1 = 0;                                                           \
+    (gate).type = (istrap) ? STS_TG32 : STS_IG32;                              \
+    (gate).s = 0;                                                              \
+    (gate).dpl = (d);                                                          \
+    (gate).p = 1;                                                              \
+    (gate).off_31_16 = (uint32_t)(off) >> 16;                                  \
+  }
+
+#endif
+
+/* ==== minix/kernel/mmu.h ==== */
+#pragma once
+
+// This file contains definitions for the
+// x86 memory management unit (MMU).
+
+// Eflags register
+#define FL_IF 0x00000200 // Interrupt Enable
+
+// Control Register flags
+#define CR0_PE 0x00000001 // Protection Enable
+#define CR0_WP 0x00010000 // Write Protect
+#define CR0_PG 0x80000000 // Paging
+
+#define CR4_PSE 0x00000010 // Page size extension
+
+// various segment selectors.
+#define SEG_KCODE 1 // kernel code
+#define SEG_KDATA 2 // kernel data+stack
+#define SEG_UCODE 3 // user code
+#define SEG_UDATA 4 // user data+stack
+#define SEG_TSS 5   // this process's task state
+
+// cpu->gdt[NSEGS] holds the above segments.
+#define NSEGS 6
+
+#ifndef __ASSEMBLER__
+// Segment Descriptor
+struct segdesc {
+  uint32_t lim_15_0 : 16;  // Low bits of segment limit
+  uint32_t base_15_0 : 16; // Low bits of segment base address
+  uint32_t base_23_16 : 8; // Middle bits of segment base address
+  uint32_t type : 4;       // Segment type (see STS_ constants)
+  uint32_t s : 1;          // 0 = system, 1 = application
+  uint32_t dpl : 2;        // Descriptor Privilege Level
+  uint32_t p : 1;          // Present
+  uint32_t lim_19_16 : 4;  // High bits of segment limit
+  uint32_t avl : 1;        // Unused (available for software use)
+  uint32_t rsv1 : 1;       // Reserved
+  uint32_t db : 1;         // 0 = 16-bit segment, 1 = 32-bit segment
+  uint32_t g : 1;          // Granularity: limit scaled by 4K when set
+  uint32_t base_31_24 : 8; // High bits of segment base address
+};
+// Ensure the descriptor is exactly 8 bytes so assembly structures match
+_Static_assert(sizeof(struct segdesc) == 8, "struct segdesc size incorrect");
+
+// Normal segment
+#define SEG(type, base, lim, dpl)                                              \
+  (struct segdesc){((lim) >> 12) & 0xffff,                                     \
+                   (uint32_t)(base) & 0xffff,                                  \
+                   ((uint32_t)(base) >> 16) & 0xff,                            \
+                   type,                                                       \
+                   1,                                                          \
+                   dpl,                                                        \
+                   1,                                                          \
+                   (uint32_t)(lim) >> 28,                                      \
+                   0,                                                          \
+                   0,                                                          \
+                   1,                                                          \
+                   1,                                                          \
+                   (uint32_t)(base) >> 24}
+#define SEG16(type, base, lim, dpl)                                            \
+  (struct segdesc){(lim) & 0xffff,                                             \
+                   (uint32_t)(base) & 0xffff,                                  \
+                   ((uint32_t)(base) >> 16) & 0xff,                            \
+                   type,                                                       \
+                   1,                                                          \
+                   dpl,                                                        \
+                   1,                                                          \
+                   (uint32_t)(lim) >> 16,                                      \
+                   0,                                                          \
+                   0,                                                          \
+                   1,                                                          \
+                   0,                                                          \
+                   (uint32_t)(base) >> 24}
+#endif
+
+#define DPL_USER 0x3 // User DPL
+
+// Application segment type bits
+#define STA_X 0x8 // Executable segment
+#define STA_W 0x2 // Writeable (non-executable segments)
+#define STA_R 0x2 // Readable (executable segments)
+
+// System segment type bits
+#define STS_T32A 0x9 // Available 32-bit TSS
+#define STS_IG32 0xE // 32-bit Interrupt Gate
+#define STS_TG32 0xF // 32-bit Trap Gate
+
+// A virtual address 'la' has a three-part structure as follows:
+//
+// +--------10------+-------10-------+---------12----------+
+// | Page Directory |   Page Table   | Offset within Page  |
+// |      Index     |      Index     |                     |
+// +----------------+----------------+---------------------+
+//  \--- PDX(va) --/ \--- PTX(va) --/
+
+// page directory index
+#ifdef __x86_64__
+#define PML4(va) (((uint64_t)(va) >> PML4SHIFT) & 0x1FF)
+#define PDPX(va) (((uint64_t)(va) >> PDPSHIFT) & 0x1FF)
+#define PDX(va) (((uint64_t)(va) >> PDSHIFT) & 0x1FF)
+#define PTX(va) (((uint64_t)(va) >> PTSHIFT) & 0x1FF)
+#else
+#define PDX(va) (((uint32_t)(va) >> PDXSHIFT) & 0x3FF)
+#define PTX(va) (((uint32_t)(va) >> PTXSHIFT) & 0x3FF)
+#endif
+
+// construct virtual address from indexes and offset
+#ifdef __x86_64__
+#define PGADDR(l4, l3, l2, l1, o)                                              \
+  ((uint64_t)((l4) << PML4SHIFT | (l3) << PDPSHIFT | (l2) << PDSHIFT |         \
+              (l1) << PTSHIFT | (o)))
+#else
+#define PGADDR(d, t, o) ((uint32_t)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
+#endif
+
+// Page directory and page table constants.
+#ifdef __x86_64__
+#define NPDENTRIES 512 // entries per page directory
+#define NPTENTRIES 512 // PTEs per page table
+#else
+#define NPDENTRIES 1024 // # directory entries per page directory
+#define NPTENTRIES 1024 // # PTEs per page table
+#endif
+#define PGSIZE 4096 // bytes mapped by a page
+
+#ifdef __x86_64__
+#define PTSHIFT 12
+#define PDSHIFT 21
+#define PDPSHIFT 30
+#define PML4SHIFT 39
+#else
+#define PTXSHIFT 12 // offset of PTX in a linear address
+#define PDXSHIFT 22 // offset of PDX in a linear address
+#endif
+
+#define PGROUNDUP(sz) (((sz) + PGSIZE - 1) & ~(PGSIZE - 1))
+#define PGROUNDDOWN(a) (((a)) & ~(PGSIZE - 1))
+
+// Page table/directory entry flags.
+#define PTE_P 0x001  // Present
+#define PTE_W 0x002  // Writeable
+#define PTE_U 0x004  // User
+#define PTE_PS 0x080 // Page Size
+
+// Permission flags for user page mappings
+#define PERM_R 0x1
+#define PERM_W 0x2
+#define PERM_X 0x4
+
+// Address in page table or page directory entry
+#ifdef __x86_64__
+#define PTE_ADDR(pte) ((uint64_t)(pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint64_t)(pte) & 0xFFF)
+#else
+#define PTE_ADDR(pte) ((uint32_t)(pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint32_t)(pte) & 0xFFF)
+#endif
+
+#ifndef __ASSEMBLER__
+#ifdef __x86_64__
+typedef uint64_t pte_t;
+typedef uint64_t pdpe_t;
+typedef uint64_t pml4e_t;
+#else
+typedef uint32_t pte_t;
+#endif
+
+// Task state segment format
+struct taskstate {
+  uint32_t link; // Old ts selector
+  uint32_t esp0; // Stack pointers and segment selectors
+  uint16_t ss0;  //   after an increase in privilege level
+  uint16_t padding1;
+  uint32_t *esp1;
+  uint16_t ss1;
+  uint16_t padding2;
+  uint32_t *esp2;
+  uint16_t ss2;
+  uint16_t padding3;
+  void *cr3;     // Page directory base
+  uint32_t *eip; // Saved state from last task switch
+  uint32_t eflags;
+  uint32_t eax; // More saved state (registers)
+  uint32_t ecx;
+  uint32_t edx;
+  uint32_t ebx;
+  uint32_t *esp;
+  uint32_t *ebp;
+  uint32_t esi;
+  uint32_t edi;
+  uint16_t es; // Even more saved state (segment selectors)
+  uint16_t padding4;
+  uint16_t cs;
+  uint16_t padding5;
+  uint16_t ss;
+  uint16_t padding6;
+  uint16_t ds;
+  uint16_t padding7;
+  uint16_t fs;
+  uint16_t padding8;
+  uint16_t gs;
+  uint16_t padding9;
+  uint16_t ldt;
+  uint16_t padding10;
+  uint16_t t;    // Trap on task switch
+  uint16_t iomb; // I/O map base address
+};
+
+// Gate descriptors for interrupts and traps
+struct gatedesc {
+  uint32_t off_15_0 : 16;  // low 16 bits of offset in segment
+  uint32_t cs : 16;        // code segment selector
+  uint32_t args : 5;       // # args, 0 for interrupt/trap gates
+  uint32_t rsv1 : 3;       // reserved(should be zero I guess)
+  uint32_t type : 4;       // type(STS_{IG32,TG32})
+  uint32_t s : 1;          // must be 0 (system)
+  uint32_t dpl : 2;        // descriptor(meaning new) privilege level
+  uint32_t p : 1;          // Present
+  uint32_t off_31_16 : 16; // high bits of offset in segment
+};
+
+// Set up a normal interrupt/trap gate descriptor.
+// - istrap: 1 for a trap (= exception) gate, 0 for an interrupt gate.
+//   interrupt gate clears FL_IF, trap gate leaves FL_IF alone
+// - sel: Code segment selector for interrupt/trap handler
+// - off: Offset in code segment for interrupt/trap handler
+// - dpl: Descriptor Privilege Level -
+//        the privilege level required for software to invoke
+//        this interrupt/trap gate explicitly using an int instruction.
+#define SETGATE(gate, istrap, sel, off, d)                                     \
+  {                                                                            \
+    (gate).off_15_0 = (uint32_t)(off) & 0xffff;                                \
+    (gate).cs = (sel);                                                         \
+    (gate).args = 0;                                                           \
+    (gate).rsv1 = 0;                                                           \
+    (gate).type = (istrap) ? STS_TG32 : STS_IG32;                              \
+    (gate).s = 0;                                                              \
+    (gate).dpl = (d);                                                          \
+    (gate).p = 1;                                                              \
+    (gate).off_31_16 = (uint32_t)(off) >> 16;                                  \
+  }
+
+#endif


### PR DESCRIPTION
## Summary
- undo the earlier unification commit
- add `iommu_unified.c` stacking all IOMMU sources
- add `iommu_unified.h` stacking all IOMMU headers
- gather MMU logic into `mmu_unified.c` and matching header

## Testing
- `npm test`
- `clang-format -i minix/iommu_unified.c minix/iommu_unified.h minix/kernel/mmu_unified.c minix/mmu_unified.h`
- `sudo apt-get update`
- `sudo apt-get install -y clang-18 clang-tools-18 llvm-18-dev libpolly-18-dev lld-18 lldb-18 bolt-18 build-essential binutils meson valgrind lcov`


------
https://chatgpt.com/codex/tasks/task_e_684b8f1c02548331982bddb3f074cdb7