### PR TITLE
Add Doxygen comments for libacpi

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -943,7 +943,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = minix/dag.h minix/kernel/dag_sched.c
+INPUT                  = minix/dag.h minix/kernel/dag_sched.c minix/lib/acpi
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/minix/lib/acpi/acpi.c
+++ b/minix/lib/acpi/acpi.c
@@ -37,7 +37,7 @@ int acpi_init(void) {
  * @return IRQ line or panic on error.
  */
 
-/*===========================================================================*
+/**===========================================================================*
  *				IRQ handling				     *
  *===========================================================================*/
 int acpi_get_irq(unsigned bus, unsigned dev, unsigned pin) {
@@ -69,8 +69,7 @@ int acpi_get_irq(unsigned bus, unsigned dev, unsigned pin) {
  * @param dev Device ID.
  * @param sbnr Secondary bus.
  */
-
-/*
+/**
  * tells acpi which two busses are connected by this bridge. The primary bus
  * (pbnr) must be already known to acpi and it must map dev as the connection to
  * the secondary (sbnr) bus

--- a/minix/lib/acpi/acpinex_drv.c
+++ b/minix/lib/acpi/acpinex_drv.c
@@ -54,14 +54,14 @@
 #include <sys/sunndi.h>
 #include <sys/types.h>
 
-/* Patchable through /etc/system. */
+/** Patchable through /etc/system. */
 #ifdef DEBUG
 int acpinex_debug = 1;
 #else
 int acpinex_debug = 0;
 #endif
 
-/*
+/**
  * Driver globals
  */
 static kmutex_t acpinex_lock;
@@ -83,8 +83,7 @@ static void acpinex_fm_init(acpinex_softstate_t *softsp);
 static void acpinex_fm_fini(acpinex_softstate_t *softsp);
 
 extern void make_ddi_ppd(dev_info_t *, struct ddi_parent_private_data **);
-
-/*
+/**
  * Configuration data structures
  */
 static struct bus_ops acpinex_bus_ops = {
@@ -163,8 +162,7 @@ static struct modldrv modldrv = {
 
 static struct modlinkage modlinkage = {MODREV_1, /* rev */
                                        (void *)&modldrv, NULL};
-
-/*
+/**
  * Module initialization routines.
  */
 int _init(void) {
@@ -375,8 +373,7 @@ static int init_child(dev_info_t *child) {
 
   return (DDI_SUCCESS);
 }
-
-/*
+/**
  * Control ops entry point:
  *
  * Requests handled completely:
@@ -414,7 +411,7 @@ static int acpinex_ctlops(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t op,
   return (rval);
 }
 
-/* ARGSUSED */
+/** ARGSUSED */
 static int acpinex_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp,
                            off_t offset, off_t len, caddr_t *vaddrp) {
   ACPINEX_DEBUG(CE_WARN,
@@ -524,7 +521,7 @@ static int acpinex_ioctl(dev_t dev, int cmd, intptr_t arg, int mode,
   return (rv);
 }
 
-/*
+/**
  * FMA error callback.
  * Register error handling callback with our parent. We will just call
  * our children's error callbacks and return their status.
@@ -537,7 +534,7 @@ static int acpinex_err_callback(dev_info_t *dip, ddi_fm_error_t *derr,
   return (ndi_fm_handler_dispatch(dip, NULL, derr));
 }
 
-/*
+/**
  * Initialize our FMA resources
  */
 static void acpinex_fm_init(acpinex_softstate_t *softsp) {
@@ -556,7 +553,7 @@ static void acpinex_fm_init(acpinex_softstate_t *softsp) {
   }
 }
 
-/*
+/**
  * Breakdown our FMA resources
  */
 static void acpinex_fm_fini(acpinex_softstate_t *softsp) {
@@ -567,7 +564,7 @@ static void acpinex_fm_fini(acpinex_softstate_t *softsp) {
   ddi_fm_fini(softsp->ans_dip);
 }
 
-/*
+/**
  * Initialize FMA resources for child devices.
  * Called when child calls ddi_fm_init().
  */

--- a/minix/lib/acpi/acpinex_event.c
+++ b/minix/lib/acpi/acpinex_event.c
@@ -55,7 +55,7 @@ int acpinex_event_support_remove = 0;
 static volatile uint_t acpinex_dr_event_cnt = 0;
 static ulong_t acpinex_object_type_mask[BT_BITOUL(ACPI_TYPE_NS_NODE_MAX + 1)];
 
-/*
+/**
  * Generate DR_REQ event to syseventd.
  * Please refer to sys/sysevent/dr.h for message definition.
  */
@@ -148,7 +148,7 @@ static int acpinex_event_generate_event(dev_info_t *dip, ACPI_HANDLE hdl,
   return (rv);
 }
 
-/*
+/**
  * Event handler for ACPI EJECT_REQUEST notifications.
  * EJECT_REQUEST notifications should be generated on the device to be ejected,
  * so no need to scan subtree of it.
@@ -303,7 +303,7 @@ static ACPI_STATUS acpinex_event_handle_check_one(ACPI_HANDLE hdl, UINT32 lvl,
   return (AE_ERROR);
 }
 
-/*
+/**
  * Event handler for BUS_CHECK/DEVICE_CHECK/DEVICE_CHECK_LIGHT notifications.
  * These events may be signaled on parent/ancestor of devices to be hot-added,
  * so need to scan ACPI namespace to figure out devices in question.
@@ -472,7 +472,7 @@ static void acpinex_event_system_handler(ACPI_HANDLE hdl, UINT32 type,
   acpidev_dr_unlock_all();
 }
 
-/*
+/**
  * Install event handler for ACPI system events.
  * Acpinex driver handles ACPI system events for its children,
  * device specific events will be handled by device drivers.
@@ -517,7 +517,7 @@ static int acpinex_event_install_handler(ACPI_HANDLE hdl, void *arg,
   return (rc);
 }
 
-/*
+/**
  * Uninstall event handler for ACPI system events.
  * Return DDI_SUCCESS on success, and DDI_FAILURE on failure.
  */
@@ -549,7 +549,7 @@ static int acpinex_event_uninstall_handler(ACPI_HANDLE hdl,
   return (DDI_SUCCESS);
 }
 
-/*
+/**
  * Install/uninstall ACPI system event handler for child objects of hdl.
  * Return DDI_SUCCESS on success, and DDI_FAILURE on failure.
  */


### PR DESCRIPTION
## Summary
- modernize doc comments for libacpi sources
- add libacpi to Doxygen INPUT paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c9be0b1448331bc231b4f3cd62326

## Summary by Sourcery

Modernize documentation comments to Doxygen style across the libacpi source files and update the Doxygen configuration to include the libacpi directory.

Enhancements:
- Convert in-source block comments to Doxygen-style comments in all libacpi C files.

Documentation:
- Add libacpi directory to the Doxygen INPUT paths in the Doxyfile.