### PR TITLE
Add repo tree summary and modernize legacy printf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ bootdisk
 
 limine/
 microwindows/
+cscope.*

--- a/docs/analysis/ascii_tree.txt
+++ b/docs/analysis/ascii_tree.txt
@@ -1,0 +1,114 @@
+.
+├── Analyze_File_Chaos.ps1
+├── LICENSE
+├── MINIX4_Restructure_Fixed.ps1
+├── MINIX4_Simple_Restructure.ps1
+├── Makefile
+├── Makefile.unified
+├── README.md
+├── archive
+│   ├── legacy
+│   ├── minix_legacy
+│   └── unix_v6v7
+├── docs
+│   ├── 0201633922.pdf
+│   ├── Doxyfile 3.kernel
+│   ├── Doxyfile.kernel
+│   ├── Mathematical_POSIX_Integration_Draft.md
+│   ├── POSIX_Utilities.pdf
+│   ├── PosixFromOpenGroup.pdf
+│   ├── Quantum_Safe_OS_Framework_Design.md
+│   ├── README.md
+│   ├── analysis
+│   ├── architecture
+│   ├── c033.pdf
+│   ├── coding-standards.md
+│   ├── design
+│   ├── dev-build-requirements.md
+│   ├── doxygen_html
+│   ├── feature_ideas
+│   ├── kernel_refactor_overview 3.md
+│   ├── kernel_refactor_overview.md
+│   ├── klib_userland_overview.md
+│   ├── man
+│   ├── memory-topology-updates.md
+│   ├── memory-topology.md
+│   ├── minix_legacy
+│   ├── n4217.pdf
+│   ├── posix-rt.pdf
+│   ├── susv4-2018-main
+│   └── toc.pdf
+├── meson.build
+├── meson_options.txt
+├── minix
+│   ├── 11printf.c
+│   ├── README_MINIX4.md
+│   ├── arbitrate.c
+│   ├── boot
+│   ├── call.c
+│   ├── cset.c
+│   ├── debug
+│   ├── device
+│   ├── filesystem
+│   ├── headers
+│   ├── io
+│   ├── ipc
+│   ├── legacy
+│   ├── memory
+│   ├── misc
+│   ├── process
+│   ├── signals
+│   ├── string
+│   ├── synchronization
+│   ├── tests
+│   ├── text
+│   └── utilities
+├── minix4
+│   ├── exokernel
+│   ├── include_legacy
+│   ├── libos
+│   ├── libos_legacy
+│   └── microkernel
+├── package-lock.json
+├── package.json
+├── scripts
+│   ├── acpi_files.py
+│   ├── analysis
+│   ├── analyze-allocator-calls.sh
+│   ├── automation
+│   ├── gen_acpi_tags.sh
+│   ├── git
+│   ├── run-jscpd.js
+│   └── unify_same_name.sh
+├── tar
+│   ├── bsdtar.1
+│   ├── bsdtar.h
+│   ├── bsdtar_platform.h
+│   ├── bsdtar_windows.c
+│   ├── bsdtar_windows.h
+│   ├── cmdline.c
+│   ├── getdate.c
+│   ├── read.c
+│   ├── subst.c
+│   ├── test
+│   ├── tree.c
+│   ├── tree.h
+│   └── util.c
+├── test
+│   └── basic.test.js
+├── tools
+│   ├── analysis
+│   ├── mail
+│   ├── mkboot
+│   ├── packages.install
+│   ├── release
+│   ├── release.sh
+│   └── testing
+└── userspace
+    ├── applications
+    ├── commands_legacy
+    ├── minix_commands
+    ├── usr_bin_legacy
+    └── usr_sbin_legacy
+
+56 directories, 56 files

--- a/minix/11printf.c
+++ b/minix/11printf.c
@@ -4,51 +4,59 @@
 #undef putchar
 #endif
 
-printf(fmt, args)
-{
+/**
+ * @brief Legacy wrapper around _doprnt.
+ *
+ * This function predates ANSI prototypes and mimics the historical
+ * ``printf`` implementation. It simply forwards the format string and
+ * argument list to ``_doprnt``.
+ */
+void printf(char *fmt, int args) { _doprnt(fmt, &args, 0); }
 
-	_doprnt(fmt, &args, 0);
-}
+/**
+ * @brief Output a formatted string with padding.
+ *
+ * @param string  The string to output.
+ * @param count   Number of characters to emit.
+ * @param adjust  Padding adjustment value.
+ * @param file    Optional output file handle.
+ * @param fillch  Padding character.
+ */
+static void _strout(
+    char *string, int count, int adjust, struct { int a; } * file, int fillch) {
 
-_strout(string, count, adjust, file, fillch)
-register char *string;
-register int count;
-int adjust;
-register struct { int a; } *file;
-{
-
-	while (adjust < 0) {
-		if (*string=='-' && fillch=='0') {
+  while (adjust < 0) {
+    if (*string == '-' && fillch == '0') {
 #ifdef TRACE
-			if (file)
-				putc(*string++, file);
-			else
+      if (file)
+        putc(*string++, file);
+      else
 #endif
-				putchar(*string++);
-			count--;
-		}
+        putchar(*string++);
+      count--;
+    }
 #ifdef TRACE
-		if (file)
-			putc(fillch, file);
-		else
+    if (file)
+      putc(fillch, file);
+    else
 #endif
-			putchar(fillch);
-		adjust++;
-	}
-	while (--count>=0)
+      putchar(fillch);
+    adjust++;
+  }
+  while (--count >= 0)
 #ifdef TRACE
-		if (file)
-			putc(*string++, file);
-		else
+    if (file)
+      putc(*string++, file);
+    else
 #endif
-			putchar(*string++);
-	while (adjust) {
+      putchar(*string++);
+  while (adjust) {
 #ifdef TRACE
-		if (file)
-			putc(fillch, file);
-		else
+    if (file)
+      putc(fillch, file);
+    else
 #endif
-			putchar(fillch);
-		adjust--;
-	}
+      putchar(fillch);
+    adjust--;
+  }
 }


### PR DESCRIPTION
## Summary
- generate repository ASCII tree for quick directory overview
- update `.gitignore` for cscope outputs
- document legacy `printf` implementation with Doxygen comments
- format `11printf.c` with clang-format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f98f3f15483319d351584aa985530

## Summary by Sourcery

Add a repository ASCII tree for directory overview, extend .gitignore for cscope outputs, and modernize the legacy printf code by applying ANSI prototypes, clang-format styling, and Doxygen documentation.

New Features:
- Generate repository ASCII tree for quick directory overview

Enhancements:
- Modernize legacy printf implementation with ANSI-style definitions and clang-format formatting
- Add Doxygen comments to document legacy printf and _strout functions
- Update .gitignore to ignore cscope output files

Documentation:
- Add repository tree summary under docs/analysis/ascii_tree.txt